### PR TITLE
fix: 前端请求层重构 + 待修复清单全量修复 + 多后端地址配置

### DIFF
--- a/backend-data/backend/app/api/routes/data_items.py
+++ b/backend-data/backend/app/api/routes/data_items.py
@@ -34,9 +34,9 @@ def list_data_items(
     offset: int = Query(default=0, ge=0),
     service: DataItemService = Depends(get_service),
 ) -> dict:
-    items = service.list(namespace=namespace, limit=limit, offset=offset)
+    items, total = service.list_with_count(namespace=namespace, limit=limit, offset=offset)
     data = [DataItemRead.model_validate(item).model_dump(mode="json") for item in items]
-    return success_response(data)
+    return success_response({"items": data, "total": total})
 
 
 @router.get("/{item_id}", response_model=ApiResponse)

--- a/backend-data/backend/app/repositories/data_item_repo.py
+++ b/backend-data/backend/app/repositories/data_item_repo.py
@@ -37,6 +37,14 @@ class DataItemRepository:
         return list(self.session.scalars(statement))
 
     def count(self, namespace: str | None = None) -> int:
+        """统计未软删的数据条目数量。
+
+        Args:
+            namespace: 可选命名空间过滤条件，为 None 时统计全量。
+
+        Returns:
+            符合条件的记录数，无数据时返回 0。
+        """
         statement = select(func.count()).select_from(DataItem).where(DataItem.deleted_at.is_(None))
         if namespace:
             statement = statement.where(DataItem.namespace == namespace)

--- a/backend-data/backend/app/repositories/data_item_repo.py
+++ b/backend-data/backend/app/repositories/data_item_repo.py
@@ -1,7 +1,7 @@
 from datetime import UTC, datetime
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from app.models.data_item import DataItem
@@ -35,6 +35,12 @@ class DataItemRepository:
             .offset(offset)
         )
         return list(self.session.scalars(statement))
+
+    def count(self, namespace: str | None = None) -> int:
+        statement = select(func.count()).select_from(DataItem).where(DataItem.deleted_at.is_(None))
+        if namespace:
+            statement = statement.where(DataItem.namespace == namespace)
+        return self.session.scalar(statement) or 0
 
     def get(self, item_id: UUID) -> DataItem | None:
         statement = select(DataItem).where(

--- a/backend-data/backend/app/services/data_item_service.py
+++ b/backend-data/backend/app/services/data_item_service.py
@@ -22,6 +22,16 @@ class DataItemService:
     ) -> list[DataItem]:
         return self.repository.list(namespace=namespace, limit=limit, offset=offset)
 
+    def list_with_count(
+        self,
+        namespace: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> tuple[list[DataItem], int]:
+        items = self.repository.list(namespace=namespace, limit=limit, offset=offset)
+        total = self.repository.count(namespace=namespace)
+        return items, total
+
     def get(self, item_id: UUID) -> DataItem:
         item = self.repository.get(item_id)
         if item is None:

--- a/backend-data/backend/app/services/data_item_service.py
+++ b/backend-data/backend/app/services/data_item_service.py
@@ -28,6 +28,16 @@ class DataItemService:
         limit: int = 50,
         offset: int = 0,
     ) -> tuple[list[DataItem], int]:
+        """分页查询并返回 (items, total)。
+
+        Args:
+            namespace: 可选命名空间过滤条件，为 None 时不过滤。
+            limit: 单页最大条目数，默认 50。
+            offset: 查询偏移量，默认 0。
+
+        Returns:
+            二元组 (当前页数据条目列表, 符合过滤条件的总数)。
+        """
         items = self.repository.list(namespace=namespace, limit=limit, offset=offset)
         total = self.repository.count(namespace=namespace)
         return items, total

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,12 +1,22 @@
 # 前端环境变量示例
 # 复制为 .env 并按需修改
 
+# ===== 浏览器侧：axios baseURL（前端请求类读取）=====
+
 # Backend Agent API 基础路径
-# 开发环境默认走 Vite proxy（见 vite.config.ts 的 /backend-agent-api 代理配置），无需设置
+# 开发环境默认走 Vite proxy（见下方 VITE_BACKEND_AGENT_TARGET），无需设置
 # 生产环境或直连后端时设置为 http://127.0.0.1:8765
 # VITE_API_BASE_URL=/backend-agent-api
 
 # 数据中台 API 基础路径
-# 开发环境默认走 Vite proxy（见 vite.config.ts 的 /data-platform-api 代理配置），无需设置
+# 开发环境默认走 Vite proxy（见下方 VITE_DATA_PLATFORM_TARGET），无需设置
 # 生产环境或直连后端时设置为 http://127.0.0.1:8010
 # VITE_DATA_PLATFORM_API_BASE_URL=/data-platform-api
+
+# ===== 开发服务器侧：Vite dev proxy 目标地址（vite.config.ts 读取）=====
+
+# backend-agent 代理目标（开发环境）
+# VITE_BACKEND_AGENT_TARGET=http://127.0.0.1:8765
+
+# 数据中台代理目标（开发环境）
+# VITE_DATA_PLATFORM_TARGET=http://127.0.0.1:8010

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -2,9 +2,9 @@
 # 复制为 .env 并按需修改
 
 # Backend Agent API 基础路径
-# 开发环境默认走 Vite proxy（见 vite.config.ts 的 /api 代理配置），无需设置
+# 开发环境默认走 Vite proxy（见 vite.config.ts 的 /backend-agent-api 代理配置），无需设置
 # 生产环境或直连后端时设置为 http://127.0.0.1:8765
-# VITE_API_BASE_URL=/api
+# VITE_API_BASE_URL=/backend-agent-api
 
 # 数据中台 API 基础路径
 # 开发环境默认走 Vite proxy（见 vite.config.ts 的 /data-platform-api 代理配置），无需设置

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,12 @@
+# 前端环境变量示例
+# 复制为 .env 并按需修改
+
+# Backend Agent API 基础路径
+# 开发环境默认走 Vite proxy（见 vite.config.ts 的 /api 代理配置），无需设置
+# 生产环境或直连后端时设置为 http://127.0.0.1:8765
+# VITE_API_BASE_URL=/api
+
+# 数据中台 API 基础路径
+# 开发环境默认走 Vite proxy（见 vite.config.ts 的 /data-platform-api 代理配置），无需设置
+# 生产环境或直连后端时设置为 http://127.0.0.1:8010
+# VITE_DATA_PLATFORM_API_BASE_URL=/data-platform-api

--- a/frontend/docs/frontend-development-spec.md
+++ b/frontend/docs/frontend-development-spec.md
@@ -2,7 +2,7 @@
 
 ## 1. 文档目标与适用范围
 
-本规范适用于 `wecom-bot-agent-console` 前端仓库的日常开发、协作评审与开源贡献。
+本规范适用于 `digital-employee-frontend` 前端仓库的日常开发、协作评审与开源贡献。
 
 目标如下：
 

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -17,6 +17,7 @@ export default defineConfig([
     ],
     rules: {
       semi: ['error', 'always'],
+      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
     },
     languageOptions: {
       globals: globals.browser,

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "wecom-bot-agent-console",
+  "name": "digital-employee-frontend",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "wecom-bot-agent-console",
+      "name": "digital-employee-frontend",
       "version": "0.1.0",
       "dependencies": {
         "antd": "6.4.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "wecom-bot-agent-console",
+  "name": "digital-employee-frontend",
   "private": true,
   "version": "0.1.0",
   "type": "module",

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,0 +1,24 @@
+import backendAgentRequest from '@/utils/backend-agent-request';
+
+/** 登录请求参数 */
+export interface LoginPayload {
+  username: string;
+  password: string;
+}
+
+/** 登录响应数据 */
+export interface LoginResult {
+  token: string;
+  username: string;
+  permission: string;
+}
+
+/** 调用 backend-agent 登录接口，返回 token 与用户信息 */
+export function loginConsole(payload: LoginPayload): Promise<LoginResult> {
+  return backendAgentRequest.post<LoginResult>('/api/auth/login', payload);
+}
+
+/** 调用 backend-agent 登出接口 */
+export function logoutConsole(): Promise<void> {
+  return backendAgentRequest.post<void>('/api/auth/logout');
+}

--- a/frontend/src/components/Layout/components/SiderMenu.tsx
+++ b/frontend/src/components/Layout/components/SiderMenu.tsx
@@ -1,20 +1,33 @@
 import { Layout, Menu } from 'antd';
 import { AppstoreOutlined, BuildOutlined, DatabaseOutlined, DashboardOutlined, SettingOutlined, TableOutlined } from '@ant-design/icons';
+import { useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import logo from '@/assets/images/avatar/logo.svg';
 import styles from '../index.module.css';
 
 const { Sider } = Layout;
 
+const DATA_PLATFORM_KEY = 'data-platform';
+
 export default function SiderMenu() {
   const navigate = useNavigate();
   const location = useLocation();
+
+  // 派生 state 模式：路由决定 data-platform 子菜单是否强制展开，
+  // 用户在其他页面可手动展开/折叠；在 data-platform 页面时强制展开（符合 UX 预期）
+  const [dpManuallyOpen, setDpManuallyOpen] = useState<boolean>(false);
+  const isOnDataPlatform = location.pathname.startsWith('/data-platform');
+  const openKeys = isOnDataPlatform || dpManuallyOpen ? [DATA_PLATFORM_KEY] : [];
+
+  const handleOpenChange = (keys: string[]): void => {
+    setDpManuallyOpen(keys.includes(DATA_PLATFORM_KEY));
+  };
 
   const menuItems = [
     { key: '/', icon: <AppstoreOutlined />, label: '页面 A' },
     { key: '/page-b', icon: <BuildOutlined />, label: '页面 B' },
     {
-      key: 'data-platform',
+      key: DATA_PLATFORM_KEY,
       icon: <DatabaseOutlined />,
       label: '数据中台',
       children: [
@@ -25,9 +38,7 @@ export default function SiderMenu() {
     },
   ];
 
-  // 当前路径匹配父级菜单，便于子菜单自动展开与高亮
   const selectedKeys = [location.pathname];
-  const openKeys = location.pathname.startsWith('/data-platform') ? ['data-platform'] : [];
 
   return (
     <Sider theme="dark" width={220}>
@@ -39,7 +50,8 @@ export default function SiderMenu() {
         theme="dark"
         mode="inline"
         selectedKeys={selectedKeys}
-        defaultOpenKeys={openKeys}
+        openKeys={openKeys}
+        onOpenChange={handleOpenChange}
         onClick={({ key }) => navigate(key)}
         items={menuItems}
       />

--- a/frontend/src/pages/data-platform-data-items/DataPlatformDataItems.tsx
+++ b/frontend/src/pages/data-platform-data-items/DataPlatformDataItems.tsx
@@ -20,6 +20,8 @@ import styles from './index.module.css';
 
 const { Title, Text } = Typography;
 
+const DEFAULT_PAGE_SIZE = 10;
+
 function parsePayload(values: DataItemFormValues): DataItemPayload {
   return {
     namespace: values.namespace,
@@ -37,19 +39,41 @@ export default function DataPlatformDataItems() {
   const [editingId, setEditingId] = useState<string>('');
   const [namespaceFilter, setNamespaceFilter] = useState<string>('');
   const [items, setItems] = useState<DataItem[]>([]);
+  const [total, setTotal] = useState<number>(0);
+  const [page, setPage] = useState<number>(1);
+  const [pageSize, setPageSize] = useState<number>(DEFAULT_PAGE_SIZE);
   const [currentJson, setCurrentJson] = useState<string>('');
   const [formValues, setFormValues] = useState<DataItemFormValues>(DEFAULT_FORM_VALUE);
 
-  async function loadItems(): Promise<void> {
+  async function loadItems(pageNum = page, pageSz = pageSize): Promise<void> {
     setLoading(true);
     try {
-      const list = await listDataItems(namespaceFilter);
-      setItems(list);
+      let result = await listDataItems(namespaceFilter, pageSz, (pageNum - 1) * pageSz);
+      // 删除最后一页的最后一条后，后端返回空数组 — 自动回退到最后一页
+      if (result.items.length === 0 && result.total > 0 && pageNum > 1) {
+        const lastPage = Math.max(1, Math.ceil(result.total / pageSz));
+        pageNum = lastPage;
+        setPage(lastPage);
+        result = await listDataItems(namespaceFilter, pageSz, (pageNum - 1) * pageSz);
+      }
+      setItems(result.items);
+      setTotal(result.total);
     } catch (error) {
       message.error(getDataPlatformErrorMessage(error));
     } finally {
       setLoading(false);
     }
+  }
+
+  function handlePageChange(newPage: number, newPageSize: number): void {
+    setPage(newPage);
+    setPageSize(newPageSize);
+    void loadItems(newPage, newPageSize);
+  }
+
+  function handleQuery(): void {
+    setPage(1);
+    void loadItems(1, pageSize);
   }
 
   function openCreate(): void {
@@ -135,9 +159,13 @@ export default function DataPlatformDataItems() {
       <DataItemsTable
         loading={loading}
         dataSource={items}
+        total={total}
+        page={page}
+        pageSize={pageSize}
+        onPageChange={handlePageChange}
         namespaceFilter={namespaceFilter}
         onNamespaceFilterChange={setNamespaceFilter}
-        onQuery={() => void loadItems()}
+        onQuery={handleQuery}
         onShowJson={showJson}
         onEdit={openEdit}
         onDelete={removeItem}

--- a/frontend/src/pages/data-platform-data-items/api/data-items-api.ts
+++ b/frontend/src/pages/data-platform-data-items/api/data-items-api.ts
@@ -1,10 +1,18 @@
 import dataPlatformRequest from '@/utils/data-platform-request';
-import type { DataItem, DataItemPayload } from '../types/data-items';
+import type { DataItem, DataItemPayload, PaginatedDataItems } from '../types/data-items';
 
-// 列表查询，namespace 可选过滤
-export async function listDataItems(namespace?: string): Promise<DataItem[]> {
-  return dataPlatformRequest.get<DataItem[]>('/api/v1/data-items', {
-    params: { namespace: namespace || undefined },
+// 列表查询，namespace 可选过滤，支持分页
+export async function listDataItems(
+  namespace?: string,
+  limit?: number,
+  offset?: number,
+): Promise<PaginatedDataItems> {
+  return dataPlatformRequest.get<PaginatedDataItems>('/api/v1/data-items', {
+    params: {
+      namespace: namespace || undefined,
+      limit,
+      offset,
+    },
   });
 }
 

--- a/frontend/src/pages/data-platform-data-items/components/DataItemsTable.tsx
+++ b/frontend/src/pages/data-platform-data-items/components/DataItemsTable.tsx
@@ -83,7 +83,7 @@ export default function DataItemsTable({
           pageSize: pageSize,
           total: total,
           showSizeChanger: true,
-          showTotal: (t) => `共 ${t} 条`,
+          showTotal: (total) => `共 ${total} 条`,
           onChange: (p, ps) => onPageChange(p, ps),
         }}
         bordered

--- a/frontend/src/pages/data-platform-data-items/components/DataItemsTable.tsx
+++ b/frontend/src/pages/data-platform-data-items/components/DataItemsTable.tsx
@@ -6,6 +6,10 @@ import type { DataItem } from '../types/data-items';
 export interface DataItemsTableProps {
   loading: boolean;
   dataSource: DataItem[];
+  total: number;
+  page: number;
+  pageSize: number;
+  onPageChange: (page: number, pageSize: number) => void;
   namespaceFilter: string;
   onNamespaceFilterChange: (value: string) => void;
   onQuery: () => void;
@@ -17,6 +21,10 @@ export interface DataItemsTableProps {
 export default function DataItemsTable({
   loading,
   dataSource,
+  total,
+  page,
+  pageSize,
+  onPageChange,
   namespaceFilter,
   onNamespaceFilterChange,
   onQuery,
@@ -70,7 +78,14 @@ export default function DataItemsTable({
         loading={loading}
         columns={columns}
         dataSource={dataSource}
-        pagination={false}
+        pagination={{
+          current: page,
+          pageSize: pageSize,
+          total: total,
+          showSizeChanger: true,
+          showTotal: (t) => `共 ${t} 条`,
+          onChange: (p, ps) => onPageChange(p, ps),
+        }}
         bordered
       />
     </>

--- a/frontend/src/pages/data-platform-data-items/types/data-items.ts
+++ b/frontend/src/pages/data-platform-data-items/types/data-items.ts
@@ -17,6 +17,11 @@ export interface DataItemPayload {
   description: string;
 }
 
+export interface PaginatedDataItems {
+  items: DataItem[];
+  total: number;
+}
+
 // 表单初始值
 export const DEFAULT_FORM_VALUE: DataItemFormValues = {
   namespace: 'default',

--- a/frontend/src/utils/backend-agent-request.ts
+++ b/frontend/src/utils/backend-agent-request.ts
@@ -17,7 +17,7 @@ export interface AgentApiResponse<T> {
  */
 class BackendAgentRequest extends BaseRequest {
   constructor() {
-    super(import.meta.env.VITE_API_BASE_URL || '/api');
+    super(import.meta.env.VITE_API_BASE_URL || '/backend-agent-api');
   }
 
   protected isSuccess(body: unknown): boolean {

--- a/frontend/src/utils/backend-agent-request.ts
+++ b/frontend/src/utils/backend-agent-request.ts
@@ -9,6 +9,18 @@ export interface AgentApiResponse<T> {
   data: T;
 }
 
+/** 类型守卫：判断响应体是否为 backend-agent 响应信封形状 */
+function isAgentResponse(body: unknown): body is AgentApiResponse<unknown> {
+  return (
+    body != null &&
+    typeof body === 'object' &&
+    'code' in body &&
+    'message' in body &&
+    'data' in body &&
+    typeof (body as { code: unknown }).code === 'number'
+  );
+}
+
 /**
  * BackendAgentRequest — 对接 backend-agent (port 8765) 的请求类。
  *
@@ -21,22 +33,16 @@ class BackendAgentRequest extends BaseRequest {
   }
 
   protected isSuccess(body: unknown): boolean {
-    return (
-      body != null &&
-      typeof body === 'object' &&
-      'code' in body &&
-      (body as AgentApiResponse<unknown>).code === 200
-    );
+    return isAgentResponse(body) && body.code === 200;
   }
 
   protected extractData(body: unknown): unknown {
-    return (body as AgentApiResponse<unknown>).data;
+    return isAgentResponse(body) ? body.data : undefined;
   }
 
   protected getErrorMessage(body: unknown): string {
-    if (body && typeof body === 'object' && 'message' in body) {
-      const msg = (body as { message?: unknown }).message;
-      if (typeof msg === 'string') return msg;
+    if (isAgentResponse(body) && typeof body.message === 'string') {
+      return body.message;
     }
     return '业务请求失败';
   }

--- a/frontend/src/utils/backend-agent-request.ts
+++ b/frontend/src/utils/backend-agent-request.ts
@@ -1,0 +1,59 @@
+import type { InternalAxiosRequestConfig } from 'axios';
+import { BaseRequest } from './request';
+import { useUserStore } from '../store/user';
+
+/** backend-agent 响应信封：{ code, message, data } */
+export interface AgentApiResponse<T> {
+  code: number;
+  message: string;
+  data: T;
+}
+
+/**
+ * BackendAgentRequest — 对接 backend-agent (port 8765) 的请求类。
+ *
+ * 响应格式：{ code, message, data }，code === 200 表示成功。
+ * 带 Bearer token 认证，401/403 时清除用户状态。
+ */
+class BackendAgentRequest extends BaseRequest {
+  constructor() {
+    super(import.meta.env.VITE_API_BASE_URL || '/api');
+  }
+
+  protected isSuccess(body: unknown): boolean {
+    return (
+      body != null &&
+      typeof body === 'object' &&
+      'code' in body &&
+      (body as AgentApiResponse<unknown>).code === 200
+    );
+  }
+
+  protected extractData(body: unknown): unknown {
+    return (body as AgentApiResponse<unknown>).data;
+  }
+
+  protected getErrorMessage(body: unknown): string {
+    if (body && typeof body === 'object' && 'message' in body) {
+      const msg = (body as { message?: unknown }).message;
+      if (typeof msg === 'string') return msg;
+    }
+    return '业务请求失败';
+  }
+
+  protected onRequest(config: InternalAxiosRequestConfig): void {
+    const token = localStorage.getItem('token');
+    if (token && config.headers) {
+      config.headers['Authorization'] = `Bearer ${token}`;
+    }
+  }
+
+  protected onAuthError(): void {
+    useUserStore.getState().clearUserInfo();
+    localStorage.removeItem('token');
+  }
+}
+
+const backendAgentRequest = new BackendAgentRequest();
+
+export default backendAgentRequest;

--- a/frontend/src/utils/data-platform-request.ts
+++ b/frontend/src/utils/data-platform-request.ts
@@ -1,83 +1,50 @@
-import axios, {
-  type AxiosInstance,
-  type AxiosRequestConfig,
-  type AxiosResponse,
-  type InternalAxiosRequestConfig,
-} from 'axios';
-import { message } from 'antd';
+import { BaseRequest, getRequestErrorMessage } from './request';
 
-// 数据中台响应信封：{ success, message, data }
+/** 数据中台响应信封：{ success, message, data } */
 export interface DataPlatformApiResponse<T> {
   success: boolean;
   message: string;
   data: T;
 }
 
-const instance: AxiosInstance = axios.create({
-  baseURL: import.meta.env.VITE_DATA_PLATFORM_API_BASE_URL || '/data-platform-api',
-  timeout: 10000,
-  headers: {
-    'Content-Type': 'application/json',
-  },
-});
+/**
+ * DataPlatformRequest — 对接 backend-data (port 8010) 的请求类。
+ *
+ * 响应格式：{ success, message, data }，success === true 表示成功。
+ * 无 token 认证，无 401/403 处理。
+ */
+class DataPlatformRequest extends BaseRequest {
+  constructor() {
+    super(import.meta.env.VITE_DATA_PLATFORM_API_BASE_URL || '/data-platform-api');
+  }
 
-instance.interceptors.request.use(
-  (config: InternalAxiosRequestConfig) => config,
-  (error) => Promise.reject(error),
-);
+  protected isSuccess(body: unknown): boolean {
+    return (
+      body != null &&
+      typeof body === 'object' &&
+      'success' in body &&
+      (body as DataPlatformApiResponse<unknown>).success === true
+    );
+  }
 
-// 响应拦截器：解包 data.data，业务层直接拿到 T 而非 AxiosResponse<T>
-// 注意：axios 类型要求 fulfilled 返回 AxiosResponse，这里运行时返回的是 body.data，
-// 通过 as unknown as AxiosResponse 在类型层兼容，下方包装层会再次断言为 Promise<T>
-instance.interceptors.response.use(
-  (response) => {
-    const body = response.data as DataPlatformApiResponse<unknown>;
-    if (!body.success) {
-      message.error(body.message || '数据中台请求失败');
-      return Promise.reject(new Error(body.message || 'Error'));
+  protected extractData(body: unknown): unknown {
+    return (body as DataPlatformApiResponse<unknown>).data;
+  }
+
+  protected getErrorMessage(body: unknown): string {
+    if (body && typeof body === 'object' && 'message' in body) {
+      const msg = (body as { message?: unknown }).message;
+      if (typeof msg === 'string') return msg;
     }
-    return body.data as unknown as AxiosResponse;
-  },
-  (error) => {
-    if (error.response) {
-      const { status, data } = error.response;
-      switch (status) {
-        case 500:
-          message.error('数据中台内部错误，请稍后再试');
-          break;
-        default:
-          message.error(data?.message || '数据中台请求异常');
-          break;
-      }
-    } else if (error.message.includes('timeout')) {
-      message.error('数据中台请求超时，请检查网络连接');
-    } else {
-      message.error('无法连接到数据中台');
-    }
-    return Promise.reject(error);
-  },
-);
+    return '数据中台请求失败';
+  }
+}
 
-// 类型化包装：响应拦截器已解包 data.data，此处把 AxiosPromise 断言为 Promise<T>
-// 强转仅存在于封装层一处，调用方直接返回 Promise<T>，无需二次断言
-export const dataPlatformRequest = {
-  get<T>(url: string, config?: AxiosRequestConfig): Promise<T> {
-    return instance.get(url, config) as unknown as Promise<T>;
-  },
-  post<T>(url: string, data?: unknown, config?: AxiosRequestConfig): Promise<T> {
-    return instance.post(url, data, config) as unknown as Promise<T>;
-  },
-  put<T>(url: string, data?: unknown, config?: AxiosRequestConfig): Promise<T> {
-    return instance.put(url, data, config) as unknown as Promise<T>;
-  },
-  delete<T>(url: string, config?: AxiosRequestConfig): Promise<T> {
-    return instance.delete(url, config) as unknown as Promise<T>;
-  },
-};
+const dataPlatformRequest = new DataPlatformRequest();
 
 export default dataPlatformRequest;
 
-// 提取错误信息
+/** 提取错误信息（向后兼容导出） */
 export function getDataPlatformErrorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : '数据中台请求失败';
+  return getRequestErrorMessage(error, '数据中台请求失败');
 }

--- a/frontend/src/utils/data-platform-request.ts
+++ b/frontend/src/utils/data-platform-request.ts
@@ -7,6 +7,18 @@ export interface DataPlatformApiResponse<T> {
   data: T;
 }
 
+/** 类型守卫：判断响应体是否为数据中台响应信封形状 */
+function isDataPlatformResponse(body: unknown): body is DataPlatformApiResponse<unknown> {
+  return (
+    body != null &&
+    typeof body === 'object' &&
+    'success' in body &&
+    'message' in body &&
+    'data' in body &&
+    typeof (body as { success: unknown }).success === 'boolean'
+  );
+}
+
 /**
  * DataPlatformRequest — 对接 backend-data (port 8010) 的请求类。
  *
@@ -19,22 +31,16 @@ class DataPlatformRequest extends BaseRequest {
   }
 
   protected isSuccess(body: unknown): boolean {
-    return (
-      body != null &&
-      typeof body === 'object' &&
-      'success' in body &&
-      (body as DataPlatformApiResponse<unknown>).success === true
-    );
+    return isDataPlatformResponse(body) && body.success === true;
   }
 
   protected extractData(body: unknown): unknown {
-    return (body as DataPlatformApiResponse<unknown>).data;
+    return isDataPlatformResponse(body) ? body.data : undefined;
   }
 
   protected getErrorMessage(body: unknown): string {
-    if (body && typeof body === 'object' && 'message' in body) {
-      const msg = (body as { message?: unknown }).message;
-      if (typeof msg === 'string') return msg;
+    if (isDataPlatformResponse(body) && typeof body.message === 'string') {
+      return body.message;
     }
     return '数据中台请求失败';
   }

--- a/frontend/src/utils/request.ts
+++ b/frontend/src/utils/request.ts
@@ -1,63 +1,150 @@
-import axios, { type AxiosInstance, type AxiosResponse, type InternalAxiosRequestConfig } from 'axios';
+import axios, {
+  type AxiosInstance,
+  type AxiosRequestConfig,
+  type AxiosResponse,
+  type InternalAxiosRequestConfig,
+} from 'axios';
 import { message } from 'antd';
-import { useUserStore } from '../store/user';
 
-const request: AxiosInstance = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL || '/api',
-  timeout: 10000,
-  headers: {
-    'Content-Type': 'application/json',
-  },
-});
+/**
+ * BaseRequest — 所有平台请求类的抽象基类。
+ *
+ * 子类需实现：
+ *   - baseURL         目标后端地址
+ *   - isSuccess(body) 业务成功判断
+ *   - extractData(body) 从响应体提取业务数据
+ *
+ * 可选覆写：
+ *   - onRequest(config)  请求拦截（如加 token）
+ *   - onAuthError()      401/403 处理（如清用户态）
+ *   - getErrorMessage(body) 自定义错误文案
+ */
+export abstract class BaseRequest {
+  protected instance: AxiosInstance;
+  protected baseURL: string;
 
-request.interceptors.request.use(
-  (config: InternalAxiosRequestConfig) => {
-    const token = localStorage.getItem('token');
-    if (token && config.headers) {
-      config.headers['Authorization'] = `Bearer ${token}`;
-    }
-    return config;
-  },
-  (error) => {
-    return Promise.reject(error);
+  constructor(baseURL: string) {
+    this.baseURL = baseURL;
+    this.instance = axios.create({
+      baseURL: this.baseURL,
+      timeout: 10000,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+    this.setupInterceptors();
   }
-);
 
-request.interceptors.response.use(
-  (response: AxiosResponse) => {
-    const { data } = response;
-    if (data.code !== 200) {
-      message.error(data.message || '业务请求失败');
-      return Promise.reject(new Error(data.message || 'Error'));
+  // ── 子类必须实现 ────────────────────────────────
+
+  protected abstract isSuccess(body: unknown): boolean;
+
+  protected abstract extractData(body: unknown): unknown;
+
+  // ── 子类可选覆写 ────────────────────────────────
+
+  /** 请求拦截 hook，默认空实现。子类可覆写以加 token 等 */
+  protected onRequest(_config: InternalAxiosRequestConfig): void {
+    // default: no-op
+  }
+
+  /** 401/403 认证失败 hook，默认空实现。子类可覆写以清用户态 */
+  protected onAuthError(_status: number): void {
+    // default: no-op
+  }
+
+  /** 从响应体提取错误消息，子类可覆写 */
+  protected getErrorMessage(body: unknown): string {
+    if (body && typeof body === 'object' && 'message' in body) {
+      const msg = (body as { message?: unknown }).message;
+      if (typeof msg === 'string') return msg;
     }
-    return data.data;
-  },
-  (error) => {
-    if (error.response) {
-      const { status, data } = error.response;
+    return '请求失败';
+  }
+
+  // ── 公共固定实现 ────────────────────────────────
+
+  protected setupInterceptors(): void {
+    // 请求拦截：调用 hook
+    this.instance.interceptors.request.use(
+      (config: InternalAxiosRequestConfig) => {
+        this.onRequest(config);
+        return config;
+      },
+      (error) => Promise.reject(error),
+    );
+
+    // 响应拦截：只处理 HTTP 错误，业务解包在 wrapper 中做
+    this.instance.interceptors.response.use(
+      (response: AxiosResponse) => response,
+      (error) => {
+        this.handleHttpError(error);
+        return Promise.reject(error);
+      },
+    );
+  }
+
+  /** HTTP 层错误处理（timeout / 网络错误 / 4xx / 5xx） */
+  protected handleHttpError(error: unknown): void {
+    if (!(error instanceof Error)) return;
+
+    // axios error with response
+    const axiosError = error as { response?: { status: number; data?: unknown }; message?: string };
+    if (axiosError.response) {
+      const { status, data } = axiosError.response;
       switch (status) {
         case 401:
-          message.error('登录状态已过期，请重新登录');
-          useUserStore.getState().clearUserInfo();
-          localStorage.removeItem('token');
-          break;
         case 403:
-          message.error('您没有权限访问该资源');
+          this.onAuthError(status);
+          message.error(status === 401 ? '登录状态已过期，请重新登录' : '您没有权限访问该资源');
           break;
         case 500:
           message.error('服务器内部错误，请稍后再试');
           break;
         default:
-          message.error(data?.message || '网络请求异常');
+          message.error(this.getErrorMessage(data) || '网络请求异常');
           break;
       }
-    } else if (error.message.includes('timeout')) {
+    } else if (axiosError.message?.includes('timeout')) {
       message.error('请求超时，请检查网络连接');
     } else {
       message.error('无法连接到服务器');
     }
-    return Promise.reject(error);
   }
-);
 
-export default request;
+  /**
+   * 业务响应解包：校验 isSuccess，提取 data。
+   * 消除审核报告 #7 的双重 as unknown as 断言。
+   */
+  protected unwrapResponse<T>(body: unknown): T {
+    if (!this.isSuccess(body)) {
+      const msg = this.getErrorMessage(body);
+      message.error(msg);
+      throw new Error(msg);
+    }
+    return this.extractData(body) as T;
+  }
+
+  // ── 类型化包装方法 ──────────────────────────────
+
+  get<T>(url: string, config?: AxiosRequestConfig): Promise<T> {
+    return this.instance.get(url, config).then((res) => this.unwrapResponse<T>(res.data));
+  }
+
+  post<T>(url: string, data?: unknown, config?: AxiosRequestConfig): Promise<T> {
+    return this.instance.post(url, data, config).then((res) => this.unwrapResponse<T>(res.data));
+  }
+
+  put<T>(url: string, data?: unknown, config?: AxiosRequestConfig): Promise<T> {
+    return this.instance.put(url, data, config).then((res) => this.unwrapResponse<T>(res.data));
+  }
+
+  delete<T>(url: string, config?: AxiosRequestConfig): Promise<T> {
+    return this.instance.delete(url, config).then((res) => this.unwrapResponse<T>(res.data));
+  }
+}
+
+/** 通用错误信息提取 */
+export function getRequestErrorMessage(error: unknown, fallback = '请求失败'): string {
+  return error instanceof Error ? error.message : fallback;
+}

--- a/frontend/src/utils/request.ts
+++ b/frontend/src/utils/request.ts
@@ -4,13 +4,11 @@ import axios, {
   type AxiosResponse,
   type InternalAxiosRequestConfig,
 } from 'axios';
-import { message } from 'antd';
 
 /**
  * BaseRequest — 所有平台请求类的抽象基类。
  *
  * 子类需实现：
- *   - baseURL         目标后端地址
  *   - isSuccess(body) 业务成功判断
  *   - extractData(body) 从响应体提取业务数据
  *
@@ -18,6 +16,9 @@ import { message } from 'antd';
  *   - onRequest(config)  请求拦截（如加 token）
  *   - onAuthError()      401/403 处理（如清用户态）
  *   - getErrorMessage(body) 自定义错误文案
+ *
+ * 错误处理策略：基类不展示错误（不耦合 UI 库），仅将错误 normalize 为
+ * 带 friendly message 的 Error 抛出。调用方在 catch 中自行展示。
  */
 export abstract class BaseRequest {
   protected instance: AxiosInstance;
@@ -74,53 +75,49 @@ export abstract class BaseRequest {
       (error) => Promise.reject(error),
     );
 
-    // 响应拦截：只处理 HTTP 错误，业务解包在 wrapper 中做
+    // 响应拦截：normalize HTTP 错误为 friendly Error，不展示
     this.instance.interceptors.response.use(
       (response: AxiosResponse) => response,
       (error) => {
-        this.handleHttpError(error);
-        return Promise.reject(error);
+        const friendlyMessage = this.getHttpErrorMessage(error);
+        return Promise.reject(new Error(friendlyMessage));
       },
     );
   }
 
-  /** HTTP 层错误处理（timeout / 网络错误 / 4xx / 5xx） */
-  protected handleHttpError(error: unknown): void {
-    if (!(error instanceof Error)) return;
+  /** 将 HTTP 错误 normalize 为用户友好的消息字符串 */
+  protected getHttpErrorMessage(error: unknown): string {
+    if (!(error instanceof Error)) return '请求失败';
 
-    // axios error with response
     const axiosError = error as { response?: { status: number; data?: unknown }; message?: string };
     if (axiosError.response) {
       const { status, data } = axiosError.response;
       switch (status) {
         case 401:
-        case 403:
           this.onAuthError(status);
-          message.error(status === 401 ? '登录状态已过期，请重新登录' : '您没有权限访问该资源');
-          break;
+          return '登录状态已过期，请重新登录';
+        case 403:
+          return '您没有权限访问该资源';
         case 500:
-          message.error('服务器内部错误，请稍后再试');
-          break;
+          return '服务器内部错误，请稍后再试';
         default:
-          message.error(this.getErrorMessage(data) || '网络请求异常');
-          break;
+          return this.getErrorMessage(data) || '网络请求异常';
       }
     } else if (axiosError.message?.includes('timeout')) {
-      message.error('请求超时，请检查网络连接');
+      return '请求超时，请检查网络连接';
     } else {
-      message.error('无法连接到服务器');
+      return '无法连接到服务器';
     }
   }
 
   /**
    * 业务响应解包：校验 isSuccess，提取 data。
    * 消除审核报告 #7 的双重 as unknown as 断言。
+   * 业务失败时 throw Error，不展示（调用方 catch 展示）。
    */
   protected unwrapResponse<T>(body: unknown): T {
     if (!this.isSuccess(body)) {
-      const msg = this.getErrorMessage(body);
-      message.error(msg);
-      throw new Error(msg);
+      throw new Error(this.getErrorMessage(body));
     }
     return this.extractData(body) as T;
   }

--- a/frontend/src/utils/request.ts
+++ b/frontend/src/utils/request.ts
@@ -5,6 +5,20 @@ import axios, {
   type InternalAxiosRequestConfig,
 } from 'axios';
 
+/** 响应体形状探测：是否包含指定字段 */
+function hasField<T extends string>(body: unknown, field: T): body is Record<T, unknown> {
+  return body != null && typeof body === 'object' && field in body;
+}
+
+/** 从 unknown 响应体中安全读取 string 类型 message 字段 */
+function readMessageField(body: unknown, fallback: string): string {
+  if (hasField(body, 'message')) {
+    const msg = body.message;
+    if (typeof msg === 'string') return msg;
+  }
+  return fallback;
+}
+
 /**
  * BaseRequest — 所有平台请求类的抽象基类。
  *
@@ -22,12 +36,10 @@ import axios, {
  */
 export abstract class BaseRequest {
   protected instance: AxiosInstance;
-  protected baseURL: string;
 
   constructor(baseURL: string) {
-    this.baseURL = baseURL;
     this.instance = axios.create({
-      baseURL: this.baseURL,
+      baseURL,
       timeout: 10000,
       headers: {
         'Content-Type': 'application/json',
@@ -56,11 +68,7 @@ export abstract class BaseRequest {
 
   /** 从响应体提取错误消息，子类可覆写 */
   protected getErrorMessage(body: unknown): string {
-    if (body && typeof body === 'object' && 'message' in body) {
-      const msg = (body as { message?: unknown }).message;
-      if (typeof msg === 'string') return msg;
-    }
-    return '请求失败';
+    return readMessageField(body, '请求失败');
   }
 
   // ── 公共固定实现 ────────────────────────────────
@@ -89,25 +97,28 @@ export abstract class BaseRequest {
   protected getHttpErrorMessage(error: unknown): string {
     if (!(error instanceof Error)) return '请求失败';
 
-    const axiosError = error as { response?: { status: number; data?: unknown }; message?: string };
-    if (axiosError.response) {
-      const { status, data } = axiosError.response;
-      switch (status) {
-        case 401:
-          this.onAuthError(status);
-          return '登录状态已过期，请重新登录';
-        case 403:
-          return '您没有权限访问该资源';
-        case 500:
-          return '服务器内部错误，请稍后再试';
-        default:
-          return this.getErrorMessage(data) || '网络请求异常';
+    if (hasField(error, 'response')) {
+      const response = error.response as { status: number; data?: unknown } | undefined;
+      if (response) {
+        const { status, data } = response;
+        switch (status) {
+          case 401:
+            this.onAuthError(status);
+            return '登录状态已过期，请重新登录';
+          case 403:
+            return '您没有权限访问该资源';
+          case 500:
+            return '服务器内部错误，请稍后再试';
+          default:
+            return this.getErrorMessage(data) || '网络请求异常';
+        }
       }
-    } else if (axiosError.message?.includes('timeout')) {
-      return '请求超时，请检查网络连接';
-    } else {
-      return '无法连接到服务器';
     }
+
+    if (hasField(error, 'message') && typeof error.message === 'string') {
+      if (error.message.includes('timeout')) return '请求超时，请检查网络连接';
+    }
+    return '无法连接到服务器';
   }
 
   /**

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,10 +1,14 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
-  /** Backend Agent API 基础路径（开发环境默认走 Vite proxy /api） */
+  /** Backend Agent API 基础路径（开发环境默认走 Vite proxy /backend-agent-api） */
   readonly VITE_API_BASE_URL?: string;
   /** 数据中台 API 基础路径（开发环境默认走 Vite proxy /data-platform-api） */
   readonly VITE_DATA_PLATFORM_API_BASE_URL?: string;
+  /** backend-agent 代理目标地址（仅 vite.config.ts 读取，开发环境） */
+  readonly VITE_BACKEND_AGENT_TARGET?: string;
+  /** 数据中台代理目标地址（仅 vite.config.ts 读取，开发环境） */
+  readonly VITE_DATA_PLATFORM_TARGET?: string;
 }
 
 interface ImportMeta {

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,1 +1,12 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  /** Backend Agent API 基础路径（开发环境默认走 Vite proxy /api） */
+  readonly VITE_API_BASE_URL?: string;
+  /** 数据中台 API 基础路径（开发环境默认走 Vite proxy /data-platform-api） */
+  readonly VITE_DATA_PLATFORM_API_BASE_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "ignoreDeprecations": "6.0",
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "target": "es2023",
     "lib": ["ES2023", "DOM"],
@@ -8,10 +7,9 @@
     "types": ["vite/client"],
     "skipLibCheck": true,
 
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"],
-      "@": ["src"]
+      "@/*": ["./src/*"],
+      "@": ["./src"]
     },
 
     /* Bundler mode */

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -6,42 +6,49 @@ import { fileURLToPath } from 'url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [react()],
-  resolve: {
-    alias: [{ find: '@', replacement: path.resolve(__dirname, 'src') }],
-  },
-  server: {
-    proxy: {
-      // backend-agent 运行在 8765 端口，开发环境通过代理转发避免跨域
-      '/backend-agent-api': {
-        target: 'http://127.0.0.1:8765',
-        changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/backend-agent-api/, ''),
-      },
-      // 数据中台后端运行在 8010 端口，开发环境通过代理转发避免跨域
-      '/data-platform-api': {
-        target: 'http://127.0.0.1:8010',
-        changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/data-platform-api/, ''),
-      },
+export default defineConfig(({ mode }) => {
+  // 读取 .env 中的代理目标地址（仅开发环境使用）
+  const env = loadEnv(mode, process.cwd(), '');
+  const backendAgentTarget = env.VITE_BACKEND_AGENT_TARGET || 'http://127.0.0.1:8765';
+  const dataPlatformTarget = env.VITE_DATA_PLATFORM_TARGET || 'http://127.0.0.1:8010';
+
+  return {
+    plugins: [react()],
+    resolve: {
+      alias: [{ find: '@', replacement: path.resolve(__dirname, 'src') }],
     },
-  },
-  build: {
-    rollupOptions: {
-      output: {
-        manualChunks(id) {
-          if (id.includes('node_modules')) {
-            if (id.includes('antd')) {
-              return 'antd';
-            }
-            if (id.match(/node_modules\/(react|react-dom|react-router-dom|zustand|@types\/react|@types\/react-dom)/)) {
-              return 'react-vendor';
-            }
-            return 'vendor';
-          }
+    server: {
+      proxy: {
+        // backend-agent，开发环境通过代理转发避免跨域
+        '/backend-agent-api': {
+          target: backendAgentTarget,
+          changeOrigin: true,
+          rewrite: (p) => p.replace(/^\/backend-agent-api/, ''),
+        },
+        // 数据中台后端，开发环境通过代理转发避免跨域
+        '/data-platform-api': {
+          target: dataPlatformTarget,
+          changeOrigin: true,
+          rewrite: (p) => p.replace(/^\/data-platform-api/, ''),
         },
       },
     },
-  },
+    build: {
+      rollupOptions: {
+        output: {
+          manualChunks(id) {
+            if (id.includes('node_modules')) {
+              if (id.includes('antd')) {
+                return 'antd';
+              }
+              if (id.match(/node_modules\/(react|react-dom|react-router-dom|zustand|@types\/react|@types\/react-dom)/)) {
+                return 'react-vendor';
+              }
+              return 'vendor';
+            }
+          },
+        },
+      },
+    },
+  };
 });

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -14,10 +14,10 @@ export default defineConfig({
   server: {
     proxy: {
       // backend-agent 运行在 8765 端口，开发环境通过代理转发避免跨域
-      '/api': {
+      '/backend-agent-api': {
         target: 'http://127.0.0.1:8765',
         changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/api/, ''),
+        rewrite: (path) => path.replace(/^\/backend-agent-api/, ''),
       },
       // 数据中台后端运行在 8010 端口，开发环境通过代理转发避免跨域
       '/data-platform-api': {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -13,6 +13,12 @@ export default defineConfig({
   },
   server: {
     proxy: {
+      // backend-agent 运行在 8765 端口，开发环境通过代理转发避免跨域
+      '/api': {
+        target: 'http://127.0.0.1:8765',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ''),
+      },
       // 数据中台后端运行在 8010 端口，开发环境通过代理转发避免跨域
       '/data-platform-api': {
         target: 'http://127.0.0.1:8010',

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -7,8 +7,8 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => {
-  // 读取 .env 中的代理目标地址（仅开发环境使用）
-  const env = loadEnv(mode, process.cwd(), '');
+  // 读取 .env 中的代理目标地址（仅开发环境使用，只加载 VITE_ 前缀变量）
+  const env = loadEnv(mode, process.cwd());
   const backendAgentTarget = env.VITE_BACKEND_AGENT_TARGET || 'http://127.0.0.1:8765';
   const dataPlatformTarget = env.VITE_DATA_PLATFORM_TARGET || 'http://127.0.0.1:8010';
 


### PR DESCRIPTION
## 背景

`前端需要修复.md` 中列出 #7/#8/#13/#15/#16 五项前端阻断问题，涉及请求层类型断言滥用、分页缺总数、SiderMenu 反模式、配置散落等问题。同时项目完成多后端地址（backend-agent + 数据中台）拆分，需要标准化的请求层抽象与配置管理。

## 变更内容

### 1. 请求层架构重构（#7/#16）
- `request.ts` → `BaseRequest` 抽象基类（模板方法 + 钩子模式）
- `data-platform-request.ts` / `backend-agent-request.ts` 继承 BaseRequest
- 引入类型守卫 `hasField` / `readMessageField` / `isAgentResponse` / `isDataPlatformResponse` 替代 `as` 重复断言
- 移除冗余 `baseURL` 字段
- 解耦 antd：拦截器仅 normalize 错误，调用方 catch 展示

### 2. 分页对接（#8）
- 后端新增 `count` 方法 + `list_with_count`，返回 `{items, total}`
- 前端 `DataItemsTable` 集成 antd Pagination
- 删除最后一页后自动回退到最后一页（边界处理）
- `showTotal` 回调单字母参数 `t` 改为语义化 `total`

### 3. SiderMenu 受控（#15）
- 重构为派生 state 模式（`dpManuallyOpen` + 路由派生）
- 消除 `useEffect + setState` 反模式 + `eslint-disable`

### 4. 配置标准化
- `.env.example` 文档化所有环境变量（浏览器侧 + 开发服务器侧）
- `vite-env.d.ts` 声明 `ImportMetaEnv` 类型
- `vite.config.ts` proxy target 移至 `.env`（`loadEnv` 默认前缀，只加载 VITE_ 变量）
- 命名统一：`/backend-agent-api`、`/data-platform-api`

### 5. backend-agent-request 消费者
- 新增 `frontend/src/api/auth.ts`（`loginConsole` / `logoutConsole`），消除死代码

### 6. 其他
- `tsconfig.app.json` 移除废弃的 `baseUrl` 和无效的 `ignoreDeprecations`
- 后端 `count` / `list_with_count` 补 Google 风格 docstring
- 项目改名：`wecom-bot-agent-console` → `digital-employee-frontend`（`package.json` / `package-lock.json` / 前端规范文档）
- 6 个 commit message 与 PR 标题去除 scope（符合 git-commit 规范）

## 影响范围

- **前端请求层**：`utils/request.ts`、`utils/data-platform-request.ts`、`utils/backend-agent-request.ts`
- **前端页面**：`pages/data-platform-data-items/`（DataItemsTable、DataPlatformDataItems、api、types）
- **前端配置**：`vite.config.ts`、`.env.example`、`vite-env.d.ts`、`tsconfig.app.json`
- **前端组件**：`components/Layout/components/SiderMenu.tsx`
- **前端新增**：`src/api/auth.ts`
- **前端工程**：`package.json`、`package-lock.json`、`docs/frontend-development-spec.md`
- **后端**：`backend-data/app/repositories/data_item_repo.py`、`backend-data/app/services/data_item_service.py`、`backend-data/app/api/routes/data_items.py`

## 自检清单

- [x] 命名：目录 kebab-case、组件 PascalCase、变量/函数语义化
- [x] 类型：无新增 `any`；`as` 用类型守卫替代；函数显式返回类型
- [x] 请求：复用 `BaseRequest`，未重建请求实例；拦截器职责单一
- [x] 异常处理：错误 normalize 为 Error 抛出，调用方 catch 展示
- [x] 无用代码：`backend-agent-request.ts` 已有 `api/auth.ts` 消费
- [x] `npm run lint` 通过
- [x] `npm run build` 通过

## 风险说明

- `DataPlatformDataItems.tsx` 的 `useEffect` eslint-disable 历史债仍在（本次未扩大）
- `data-platform-system-config/api/system-api.ts` 松散类型未治理（历史债）
- force push 重写了 6 个 commit 的历史（去 scope），已知悉
- 依赖 PR #18（脚本整合 + uv）合入后再合入本 PR 可避免 diff 噪音
