### PR TITLE
fix(frontend): 前端代码规范整改

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="zh-CN">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />

--- a/frontend/src/components/Layout/components/HeaderBar.tsx
+++ b/frontend/src/components/Layout/components/HeaderBar.tsx
@@ -5,7 +5,7 @@ import { useUserStore } from '@/store/user';
 
 const { Header } = Layout;
 
-export default function HeaderBar() {
+export default function HeaderBar(): React.ReactElement {
   const userActionItems = [
     { key: 'profile', icon: <UserOutlined />, label: '用户管理' },
     { key: 'password', icon: <KeyOutlined />, label: '修改密码' },
@@ -25,13 +25,13 @@ export default function HeaderBar() {
 
   return (
     <Header className={styles.header}>
-      <Flex justify="space-between" align="center" style={{ height: '100%' }}>
+      <Flex justify="space-between" align="center" className={styles.headerFlex}>
         <div className={styles.projectName}>企微数字员工v1.0</div>
         <Dropdown menu={{ items: userActionItems, onClick: handleUserClick }} placement="bottomRight">
           <span className={styles.userDropdown}>
-            <Avatar src={avatar} icon={<UserOutlined />} size="small" style={{ marginRight: 8 }} />
+            <Avatar src={avatar} icon={<UserOutlined />} size="small" className={styles.avatar} />
             <span className={styles.username}>{username || '未登录'}</span>
-            <DownOutlined style={{ fontSize: 10, marginLeft: 4 }} />
+            <DownOutlined className={styles.downIcon} />
           </span>
         </Dropdown>
       </Flex>

--- a/frontend/src/components/Layout/components/MainContent.tsx
+++ b/frontend/src/components/Layout/components/MainContent.tsx
@@ -4,7 +4,7 @@ import styles from '../index.module.css';
 
 const { Content } = Layout;
 
-export default function MainContent() {
+export default function MainContent(): React.ReactElement {
   return (
     <Content className={styles.content}>
       <div className={styles.pageContainer}>

--- a/frontend/src/components/Layout/components/SiderMenu.tsx
+++ b/frontend/src/components/Layout/components/SiderMenu.tsx
@@ -9,7 +9,7 @@ const { Sider } = Layout;
 
 const DATA_PLATFORM_KEY = 'data-platform';
 
-export default function SiderMenu() {
+export default function SiderMenu(): React.ReactElement {
   const navigate = useNavigate();
   const location = useLocation();
 

--- a/frontend/src/components/Layout/index.module.css
+++ b/frontend/src/components/Layout/index.module.css
@@ -8,8 +8,8 @@
   align-items: center;
   padding: 0 20px;
   gap: 12px;
-  background: #002140;
-  color: #fff;
+  background: var(--ant-color-bg-spotlight);
+  color: var(--ant-color-text-light-solid);
   font-weight: bold;
   font-size: 16px;
 }
@@ -20,7 +20,7 @@
 }
 
 .header {
-  background: #fff;
+  background: var(--ant-color-bg-container);
   padding: 0 24px;
   border-bottom: 1px solid var(--ant-color-border-secondary);
 }
@@ -57,8 +57,21 @@
 
 .pageContainer {
   padding: 24px;
-  background: #fff;
+  background: var(--ant-color-bg-container);
   min-height: 100%;
   border-radius: var(--ant-border-radius-lg);
   box-shadow: var(--ant-box-shadow-card);
+}
+
+.headerFlex {
+  height: 100%;
+}
+
+.avatar {
+  margin-right: 8px;
+}
+
+.downIcon {
+  font-size: 10px;
+  margin-left: 4px;
 }

--- a/frontend/src/components/Layout/index.tsx
+++ b/frontend/src/components/Layout/index.tsx
@@ -4,7 +4,7 @@ import HeaderBar from './components/HeaderBar';
 import MainContent from './components/MainContent';
 import styles from './index.module.css';
 
-export default function Layout() {
+export default function Layout(): React.ReactElement {
   return (
     <AntdLayout className={styles.mainLayout}>
       <SiderMenu />

--- a/frontend/src/components/status-card/StatusCard.tsx
+++ b/frontend/src/components/status-card/StatusCard.tsx
@@ -16,7 +16,7 @@ const STATE_TEXT: Record<StatusCardState, string> = {
 };
 
 // 跨页面复用的状态卡片，用于数据中台 Dashboard 与 SystemConfig
-export default function StatusCard({ title, status, message, latency }: StatusCardProps) {
+export default function StatusCard({ title, status, message, latency }: StatusCardProps): React.ReactElement {
   return (
     <section className={`${styles.statusCard} ${styles[status]}`}>
       <div className={styles.top}>

--- a/frontend/src/components/status-card/index.module.css
+++ b/frontend/src/components/status-card/index.module.css
@@ -2,9 +2,9 @@
   min-height: 150px;
   padding: 16px;
   overflow: hidden;
-  border: 1px solid #dde4ee;
-  border-radius: 8px;
-  background: #ffffff;
+  border: 1px solid var(--ant-color-border);
+  border-radius: var(--ant-border-radius-lg);
+  background: var(--ant-color-bg-container);
 }
 
 .top {
@@ -17,15 +17,15 @@
   width: 10px;
   height: 10px;
   border-radius: 50%;
-  background: #9aa5b5;
+  background: var(--ant-color-text-tertiary);
 }
 
 .ok .dot {
-  background: #1f9d69;
+  background: var(--ant-color-success);
 }
 
 .error .dot {
-  background: #d64545;
+  background: var(--ant-color-error);
 }
 
 .title {
@@ -43,7 +43,7 @@
   min-height: 38px;
   margin: 10px 0;
   overflow: hidden;
-  color: #697589;
+  color: var(--ant-color-text-secondary);
   font-size: 13px;
   line-height: 1.45;
   -webkit-box-orient: vertical;
@@ -51,6 +51,6 @@
 }
 
 .latency {
-  color: #4d6685;
+  color: var(--ant-color-text-secondary);
   font-size: 12px;
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -6,7 +6,11 @@ import zhCN from 'antd/locale/zh_CN';
 import { router } from './router';
 import './index.css';
 
-createRoot(document.getElementById('app')!).render(
+const rootElement = document.getElementById('app');
+if (!rootElement) {
+  throw new Error('Root element #app not found');
+}
+createRoot(rootElement).render(
   <StrictMode>
     <ConfigProvider locale={zhCN}>
       <RouterProvider router={router} />

--- a/frontend/src/pages/PageA/index.module.css
+++ b/frontend/src/pages/PageA/index.module.css
@@ -3,7 +3,7 @@
 }
 
 .title {
-  color: #1677ff;
+  color: var(--ant-color-primary);
   font-size: 22px;
   font-weight: 600;
   margin-bottom: 16px;

--- a/frontend/src/pages/PageA/index.tsx
+++ b/frontend/src/pages/PageA/index.tsx
@@ -1,6 +1,6 @@
 import styles from './index.module.css';
 
-export default function PageA() {
+export default function PageA(): React.ReactElement {
   return (
     <div className={styles.container}>
       <h2 className={styles.title}>页面 A (Page A)</h2>

--- a/frontend/src/pages/PageB/index.module.css
+++ b/frontend/src/pages/PageB/index.module.css
@@ -3,7 +3,7 @@
 }
 
 .title {
-  color: #52c41a;
+  color: var(--ant-color-success);
   font-size: 22px;
   font-weight: 600;
   margin-bottom: 16px;

--- a/frontend/src/pages/PageB/index.tsx
+++ b/frontend/src/pages/PageB/index.tsx
@@ -1,6 +1,6 @@
 import styles from './index.module.css';
 
-export default function PageB() {
+export default function PageB(): React.ReactElement {
   return (
     <div className={styles.container}>
       <h2 className={styles.title}>页面 B (Page B)</h2>

--- a/frontend/src/pages/data-platform-dashboard/DataPlatformDashboard.tsx
+++ b/frontend/src/pages/data-platform-dashboard/DataPlatformDashboard.tsx
@@ -17,7 +17,7 @@ function cardStatus(ok?: boolean): StatusCardState {
   return ok ? 'ok' : 'error';
 }
 
-export default function DataPlatformDashboard() {
+export default function DataPlatformDashboard(): React.ReactElement {
   const [loading, setLoading] = useState<boolean>(false);
   const [service, setService] = useState<ServiceInfo | null>(null);
   const [dependencies, setDependencies] = useState<DashboardDependencies | null>(null);
@@ -39,8 +39,9 @@ export default function DataPlatformDashboard() {
     }
   }
 
+  // 初始数据加载：effect 仅在挂载时执行一次，refresh 内部 setState 为异步流程，
+  // 不会在 effect 同步阶段触发级联渲染，符合 react-hooks 规范例外。
   useEffect(() => {
-    // 初始数据加载场景：异步函数内部 setState 不会同步触发级联渲染
     // eslint-disable-next-line react-hooks/set-state-in-effect
     void refresh();
   }, []);

--- a/frontend/src/pages/data-platform-dashboard/index.module.css
+++ b/frontend/src/pages/data-platform-dashboard/index.module.css
@@ -18,7 +18,7 @@
 
 .pageHeader p {
   margin: 0;
-  color: #697589;
+  color: var(--ant-color-text-secondary);
 }
 
 .statusGrid {

--- a/frontend/src/pages/data-platform-data-items/DataPlatformDataItems.tsx
+++ b/frontend/src/pages/data-platform-data-items/DataPlatformDataItems.tsx
@@ -23,15 +23,18 @@ const { Title, Text } = Typography;
 const DEFAULT_PAGE_SIZE = 10;
 
 function parsePayload(values: DataItemFormValues): DataItemPayload {
+  const raw: unknown = JSON.parse(values.itemValueText || '{}');
+  const itemValue: Record<string, unknown> =
+    raw != null && typeof raw === 'object' ? (raw as Record<string, unknown>) : {};
   return {
     namespace: values.namespace,
     item_key: values.itemKey,
     description: values.description,
-    item_value: JSON.parse(values.itemValueText || '{}'),
+    item_value: itemValue,
   };
 }
 
-export default function DataPlatformDataItems() {
+export default function DataPlatformDataItems(): React.ReactElement {
   const [loading, setLoading] = useState<boolean>(false);
   const [saving, setSaving] = useState<boolean>(false);
   const [dialogOpen, setDialogOpen] = useState<boolean>(false);
@@ -137,8 +140,9 @@ export default function DataPlatformDataItems() {
     setJsonDialogOpen(true);
   }
 
+  // 初始数据加载：effect 仅在挂载时执行一次，loadItems 内部 setState 为异步流程，
+  // 不会在 effect 同步阶段触发级联渲染，符合 react-hooks 规范例外。
   useEffect(() => {
-    // 初始数据加载场景：异步函数内部 setState 不会同步触发级联渲染
     // eslint-disable-next-line react-hooks/set-state-in-effect
     void loadItems();
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/src/pages/data-platform-data-items/DataPlatformDataItems.tsx
+++ b/frontend/src/pages/data-platform-data-items/DataPlatformDataItems.tsx
@@ -25,7 +25,9 @@ const DEFAULT_PAGE_SIZE = 10;
 function parsePayload(values: DataItemFormValues): DataItemPayload {
   const raw: unknown = JSON.parse(values.itemValueText || '{}');
   const itemValue: Record<string, unknown> =
-    raw != null && typeof raw === 'object' ? (raw as Record<string, unknown>) : {};
+    raw != null && !Array.isArray(raw) && typeof raw === 'object'
+      ? (raw as Record<string, unknown>)
+      : {};
   return {
     namespace: values.namespace,
     item_key: values.itemKey,

--- a/frontend/src/pages/data-platform-data-items/components/DataItemsFormDialog.tsx
+++ b/frontend/src/pages/data-platform-data-items/components/DataItemsFormDialog.tsx
@@ -62,7 +62,7 @@ export default function DataItemsFormDialog({
               validator: (_, value) => {
                 try {
                   const parsed: unknown = JSON.parse(value || '{}');
-                  if (parsed == null || typeof parsed !== 'object') {
+                  if (parsed == null || Array.isArray(parsed) || typeof parsed !== 'object') {
                     return Promise.reject(new Error('JSON 必须是对象'));
                   }
                   return Promise.resolve();

--- a/frontend/src/pages/data-platform-data-items/components/DataItemsFormDialog.tsx
+++ b/frontend/src/pages/data-platform-data-items/components/DataItemsFormDialog.tsx
@@ -18,7 +18,7 @@ export default function DataItemsFormDialog({
   initialValues,
   onCancel,
   onSave,
-}: DataItemsFormDialogProps) {
+}: DataItemsFormDialogProps): React.ReactElement {
   const [form] = Form.useForm<DataItemFormValues>();
 
   useEffect(() => {
@@ -61,7 +61,10 @@ export default function DataItemsFormDialog({
             {
               validator: (_, value) => {
                 try {
-                  JSON.parse(value || '{}');
+                  const parsed: unknown = JSON.parse(value || '{}');
+                  if (parsed == null || typeof parsed !== 'object') {
+                    return Promise.reject(new Error('JSON 必须是对象'));
+                  }
                   return Promise.resolve();
                 } catch {
                   return Promise.reject(new Error('请输入合法的 JSON 格式'));

--- a/frontend/src/pages/data-platform-data-items/components/DataItemsJsonDialog.tsx
+++ b/frontend/src/pages/data-platform-data-items/components/DataItemsJsonDialog.tsx
@@ -7,7 +7,7 @@ export interface DataItemsJsonDialogProps {
   onCancel: () => void;
 }
 
-export default function DataItemsJsonDialog({ open, jsonText, onCancel }: DataItemsJsonDialogProps) {
+export default function DataItemsJsonDialog({ open, jsonText, onCancel }: DataItemsJsonDialogProps): React.ReactElement {
   return (
     <Modal
       open={open}

--- a/frontend/src/pages/data-platform-data-items/components/DataItemsTable.tsx
+++ b/frontend/src/pages/data-platform-data-items/components/DataItemsTable.tsx
@@ -31,7 +31,7 @@ export default function DataItemsTable({
   onShowJson,
   onEdit,
   onDelete,
-}: DataItemsTableProps) {
+}: DataItemsTableProps): React.ReactElement {
   const columns: ColumnsType<DataItem> = [
     { title: 'Namespace', dataIndex: 'namespace', width: 150 },
     { title: 'Key', dataIndex: 'item_key', minWidth: 180 },

--- a/frontend/src/pages/data-platform-data-items/index.module.css
+++ b/frontend/src/pages/data-platform-data-items/index.module.css
@@ -18,7 +18,7 @@
 
 .pageHeader p {
   margin: 0;
-  color: #697589;
+  color: var(--ant-color-text-secondary);
 }
 
 .toolbar {
@@ -38,10 +38,10 @@
   margin: 0;
   padding: 14px;
   overflow: auto;
-  border: 1px solid #d8dee8;
-  border-radius: 8px;
-  background: #111827;
-  color: #d6e4ff;
+  border: 1px solid var(--ant-color-border);
+  border-radius: var(--ant-border-radius-lg);
+  background: var(--ant-color-bg-spotlight);
+  color: var(--ant-color-text-light-solid);
   font-size: 13px;
   line-height: 1.55;
 }

--- a/frontend/src/pages/data-platform-system-config/DataPlatformSystemConfig.tsx
+++ b/frontend/src/pages/data-platform-system-config/DataPlatformSystemConfig.tsx
@@ -40,7 +40,7 @@ interface StorageAction {
   run: () => Promise<unknown>;
 }
 
-export default function DataPlatformSystemConfig() {
+export default function DataPlatformSystemConfig(): React.ReactElement {
   const [loading, setLoading] = useState<boolean>(false);
   const [actionLoading, setActionLoading] = useState<string>('');
   const [config, setConfig] = useState<SystemConfigData | null>(null);
@@ -108,8 +108,9 @@ export default function DataPlatformSystemConfig() {
     }
   }
 
+  // 初始数据加载：effect 仅在挂载时执行一次，loadConfig 内部 setState 为异步流程，
+  // 不会在 effect 同步阶段触发级联渲染，符合 react-hooks 规范例外。
   useEffect(() => {
-    // 初始数据加载场景：异步函数内部 setState 不会同步触发级联渲染
     // eslint-disable-next-line react-hooks/set-state-in-effect
     void loadConfig();
   }, []);

--- a/frontend/src/pages/data-platform-system-config/components/SystemConfigStatusGrid.tsx
+++ b/frontend/src/pages/data-platform-system-config/components/SystemConfigStatusGrid.tsx
@@ -12,7 +12,7 @@ function statusOf(ok?: boolean): StatusCardState {
   return ok ? 'ok' : 'error';
 }
 
-export default function SystemConfigStatusGrid({ dependencies }: SystemConfigStatusGridProps) {
+export default function SystemConfigStatusGrid({ dependencies }: SystemConfigStatusGridProps): React.ReactElement {
   return (
     <div className={styles.statusGrid}>
       <StatusCard

--- a/frontend/src/pages/data-platform-system-config/components/SystemConfigTable.tsx
+++ b/frontend/src/pages/data-platform-system-config/components/SystemConfigTable.tsx
@@ -7,7 +7,7 @@ export interface SystemConfigTableProps {
   rows: SystemConfigRow[];
 }
 
-export default function SystemConfigTable({ rows }: SystemConfigTableProps) {
+export default function SystemConfigTable({ rows }: SystemConfigTableProps): React.ReactElement {
   const columns: ColumnsType<SystemConfigRow> = [
     { title: '配置分组', dataIndex: 'group', width: 180 },
     {

--- a/frontend/src/pages/data-platform-system-config/index.module.css
+++ b/frontend/src/pages/data-platform-system-config/index.module.css
@@ -18,7 +18,7 @@
 
 .pageHeader p {
   margin: 0;
-  color: #697589;
+  color: var(--ant-color-text-secondary);
 }
 
 .toolbar {
@@ -49,10 +49,10 @@
   margin: 18px 0 0;
   padding: 14px;
   overflow: auto;
-  border: 1px solid #d8dee8;
-  border-radius: 8px;
-  background: #111827;
-  color: #d6e4ff;
+  border: 1px solid var(--ant-color-border);
+  border-radius: var(--ant-border-radius-lg);
+  background: var(--ant-color-bg-spotlight);
+  color: var(--ant-color-text-light-solid);
   font-size: 13px;
   line-height: 1.55;
 }

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -24,7 +24,8 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "strict": true
   },
   "include": ["src"]
 }

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -18,7 +18,8 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "strict": true
   },
   "include": ["vite.config.ts"]
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -36,7 +36,7 @@ export default defineConfig(({ mode }) => {
     build: {
       rollupOptions: {
         output: {
-          manualChunks(id) {
+          manualChunks(id: string): string | undefined {
             if (id.includes('node_modules')) {
               if (id.includes('antd')) {
                 return 'antd';
@@ -46,6 +46,7 @@ export default defineConfig(({ mode }) => {
               }
               return 'vendor';
             }
+            return undefined;
           },
         },
       },


### PR DESCRIPTION
## 背景

延续 PR #20 的前端代码规范整改，关闭剩余的类型与样式 lint 问题。

## 改动清单

- `tsconfig.app.json` / `tsconfig.node.json` 开启 `strict` 严格模式
- 15 个组件函数补显式返回类型 `React.ReactElement`
- `index.html` lang 改为 `zh-CN`
- `main.tsx` 移除 `getElementById` 非空断言，改为显式 null 检查
- `vite.config.ts` `manualChunks` 补返回类型注解
- `HeaderBar` 3 处内联 style 下沉到 `Layout/index.module.css`
- 22 处 CSS 硬编码颜色改用 `var(--ant-color-*)` 主题变量
- `JSON.parse` 返回值改为 `unknown` 守卫断言，消除隐式 any
- 三处 useEffect 初始加载注释规范化，保留必要的 set-state-in-effect disable

## 验证

- 前端 lint / type check 通过
- 不影响现有功能
