### PR TITLE
fix(backend-data): 补齐认证依赖与文档规范

### DIFF
--- a/backend-data/backend/.env.example
+++ b/backend-data/backend/.env.example
@@ -5,6 +5,9 @@ APP_HOST=127.0.0.1
 APP_PORT=8010
 API_PREFIX=/api/v1
 DEPENDENCY_TIMEOUT_SECONDS=3
+# 保护业务端点的 API Key，留空时跳过校验；生产环境必须配置。
+# 客户端需通过请求头 X-API-Key: <值> 携带。
+API_KEY=
 
 CORE_DB_HOST=127.0.0.1
 CORE_DB_PORT=5432

--- a/backend-data/backend/README.md
+++ b/backend-data/backend/README.md
@@ -6,7 +6,7 @@
 
 ## 技术栈
 
-- Python 3.10+
+- Python 3.11+
 - FastAPI
 - Uvicorn
 - SQLAlchemy 2.0

--- a/backend-data/backend/app/api/deps.py
+++ b/backend-data/backend/app/api/deps.py
@@ -3,6 +3,8 @@
 提供 API Key 认证依赖，用于保护非健康检查类端点。
 """
 
+import secrets
+
 from fastapi import Header, HTTPException
 
 from app.core.config import settings
@@ -14,6 +16,8 @@ async def verify_api_key(x_api_key: str | None = Header(default=None)) -> None:
     当 ``API_KEY`` 未配置时跳过校验，便于本地开发；
     生产环境应通过环境变量显式配置 ``API_KEY``。
 
+    使用 ``secrets.compare_digest`` 进行常量时间比较，避免时序攻击。
+
     Args:
         x_api_key: 请求头 ``X-API-Key`` 的值，缺失或为空表示未携带。
 
@@ -24,5 +28,5 @@ async def verify_api_key(x_api_key: str | None = Header(default=None)) -> None:
     expected = settings.api_key
     if not expected:
         return
-    if x_api_key != expected:
+    if not x_api_key or not secrets.compare_digest(x_api_key, expected):
         raise HTTPException(status_code=401, detail="invalid api key")

--- a/backend-data/backend/app/api/deps.py
+++ b/backend-data/backend/app/api/deps.py
@@ -1,0 +1,28 @@
+"""FastAPI 通用依赖。
+
+提供 API Key 认证依赖，用于保护非健康检查类端点。
+"""
+
+from fastapi import Header, HTTPException
+
+from app.core.config import settings
+
+
+async def verify_api_key(x_api_key: str | None = Header(default=None)) -> None:
+    """校验请求头 ``X-API-Key`` 是否与服务端配置一致。
+
+    当 ``API_KEY`` 未配置时跳过校验，便于本地开发；
+    生产环境应通过环境变量显式配置 ``API_KEY``。
+
+    Args:
+        x_api_key: 请求头 ``X-API-Key`` 的值，缺失或为空表示未携带。
+
+    Raises:
+        HTTPException: 当 ``API_KEY`` 已配置但请求头缺失或不匹配时，
+            返回 401 未授权。
+    """
+    expected = settings.api_key
+    if not expected:
+        return
+    if x_api_key != expected:
+        raise HTTPException(status_code=401, detail="invalid api key")

--- a/backend-data/backend/app/api/router.py
+++ b/backend-data/backend/app/api/router.py
@@ -1,15 +1,34 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
+from app.api.deps import verify_api_key
 from app.api.routes import cache, data_items, health, storage, system_config
 
 
 api_router = APIRouter()
+# 健康检查端点对外豁免，便于 K8s/负载均衡探活。
 api_router.include_router(health.router, prefix="/health", tags=["health"])
+# 业务端点统一挂载 API Key 认证依赖。
 api_router.include_router(
     system_config.router,
     prefix="/system",
     tags=["system-config"],
+    dependencies=[Depends(verify_api_key)],
 )
-api_router.include_router(data_items.router, prefix="/data-items", tags=["data-items"])
-api_router.include_router(storage.router, prefix="/storage", tags=["storage"])
-api_router.include_router(cache.router, prefix="/cache", tags=["cache"])
+api_router.include_router(
+    data_items.router,
+    prefix="/data-items",
+    tags=["data-items"],
+    dependencies=[Depends(verify_api_key)],
+)
+api_router.include_router(
+    storage.router,
+    prefix="/storage",
+    tags=["storage"],
+    dependencies=[Depends(verify_api_key)],
+)
+api_router.include_router(
+    cache.router,
+    prefix="/cache",
+    tags=["cache"],
+    dependencies=[Depends(verify_api_key)],
+)

--- a/backend-data/backend/app/api/router.py
+++ b/backend-data/backend/app/api/router.py
@@ -5,7 +5,8 @@ from app.api.routes import cache, data_items, health, storage, system_config
 
 
 api_router = APIRouter()
-# 健康检查端点对外豁免，便于 K8s/负载均衡探活。
+# 基础健康检查端点对外豁免，便于 K8s/负载均衡探活；
+# /health/dependencies 在端点级别单独挂载 API Key 认证。
 api_router.include_router(health.router, prefix="/health", tags=["health"])
 # 业务端点统一挂载 API Key 认证依赖。
 api_router.include_router(

--- a/backend-data/backend/app/api/routes/health.py
+++ b/backend-data/backend/app/api/routes/health.py
@@ -1,5 +1,6 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
+from app.api.deps import verify_api_key
 from app.schemas.common import ApiResponse
 from app.services.health_service import HealthService
 from app.utils.response import success_response
@@ -13,7 +14,13 @@ def api_health() -> dict:
     return success_response({"status": "healthy"})
 
 
-@router.get("/dependencies", response_model=ApiResponse)
+# /dependencies 返回依赖探活详情（失败时可能携带异常消息），
+# 单独挂载 API Key 认证；基础 /health 仍豁免以支持 K8s 探活。
+@router.get(
+    "/dependencies",
+    response_model=ApiResponse,
+    dependencies=[Depends(verify_api_key)],
+)
 def dependencies() -> dict:
     statuses = HealthService().test_dependencies()
     return success_response(statuses.model_dump())

--- a/backend-data/backend/app/core/config.py
+++ b/backend-data/backend/app/core/config.py
@@ -26,6 +26,8 @@ class Settings(BaseSettings):
     app_port: int = 8010
     api_prefix: str = "/api/v1"
     dependency_timeout_seconds: int = 3
+    # 用于保护非健康检查端点的 API Key；为空时跳过校验，生产环境务必配置。
+    api_key: str = Field(default="", repr=False)
 
     core_db_host: str = "127.0.0.1"
     core_db_port: int = 5432
@@ -61,6 +63,14 @@ class Settings(BaseSettings):
     @property
     def cors_origins_list(self) -> list[str]:
         return [origin.strip() for origin in self.cors_origins.split(",") if origin.strip()]
+
+    @property
+    def docs_enabled(self) -> bool:
+        """是否对外暴露 Swagger / ReDoc 文档站点。
+
+        生产环境关闭以减少攻击面，其余环境默认开启便于联调。
+        """
+        return self.app_env != "production"
 
     @staticmethod
     def _postgres_url(
@@ -113,37 +123,31 @@ class Settings(BaseSettings):
         return f"{scheme}://{auth}{self.redis_host}:{self.redis_port}/{self.redis_db}"
 
     def public_config(self) -> dict:
+        """返回可供前端展示的非敏感系统配置。
+
+        仅暴露静态的、面向排障与展示的元信息，剔除主机、端口、用户等
+        可能泄漏部署拓扑的字段。
+        """
         return {
             "app": {
                 "name": self.app_name,
                 "version": self.app_version,
                 "env": self.app_env,
-                "host": self.app_host,
-                "port": self.app_port,
                 "api_prefix": self.api_prefix,
             },
             "core_db": {
-                "host": self.core_db_host,
-                "port": self.core_db_port,
                 "database": self.core_db_name,
-                "user": self.core_db_user,
                 "sslmode": self.core_db_sslmode,
             },
             "vector_db": {
-                "host": self.vector_db_host,
-                "port": self.vector_db_port,
                 "database": self.vector_db_name,
-                "user": self.vector_db_user,
                 "sslmode": self.vector_db_sslmode,
             },
             "redis": {
-                "host": self.redis_host,
-                "port": self.redis_port,
                 "db": self.redis_db,
                 "ssl": self.redis_ssl,
             },
             "minio": {
-                "endpoint": self.minio_endpoint,
                 "secure": self.minio_secure,
                 "default_bucket": self.minio_default_bucket,
             },

--- a/backend-data/backend/app/main.py
+++ b/backend-data/backend/app/main.py
@@ -1,4 +1,5 @@
 from contextlib import asynccontextmanager
+from collections.abc import AsyncIterator
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.exceptions import RequestValidationError
@@ -13,15 +14,16 @@ from app.utils.response import fail_response
 
 
 @asynccontextmanager
-async def lifespan(app: FastAPI):
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     yield
 
 
 app = FastAPI(
     title=settings.app_name,
     version=settings.app_version,
-    docs_url="/docs",
-    redoc_url="/redoc",
+    docs_url="/docs" if settings.docs_enabled else None,
+    redoc_url="/redoc" if settings.docs_enabled else None,
+    openapi_url="/openapi.json" if settings.docs_enabled else None,
     lifespan=lifespan,
 )
 
@@ -36,9 +38,25 @@ app.add_middleware(
 
 @app.exception_handler(HTTPException)
 async def http_exception_handler(request: Request, exc: HTTPException) -> JSONResponse:
+    """统一处理 HTTPException。
+
+    对 5xx 服务端异常进行日志记录并对外脱敏；4xx 客户端异常
+    沿用 detail 文案，便于调用方定位问题。
+    """
+    if exc.status_code >= 500:
+        logger.warning(
+            "[HTTPException] {} {} status={} detail={}",
+            request.method,
+            request.url.path,
+            exc.status_code,
+            exc.detail,
+        )
+        message = "internal server error"
+    else:
+        message = str(exc.detail) if exc.detail else "error"
     return JSONResponse(
         status_code=exc.status_code,
-        content=fail_response(message=str(exc.detail)),
+        content=fail_response(message=message),
     )
 
 

--- a/backend-data/backend/app/repositories/data_item_repo.py
+++ b/backend-data/backend/app/repositories/data_item_repo.py
@@ -9,10 +9,29 @@ from app.schemas.data_item import DataItemCreate, DataItemUpdate
 
 
 class DataItemRepository:
+    """数据条目仓储层。
+
+    基于 SQLAlchemy Session 提供数据条目的持久化访问，
+    所有写操作均显式提交并刷新实例以同步数据库默认值。
+    """
+
     def __init__(self, session: Session) -> None:
+        """初始化仓储并注入会话。
+
+        Args:
+            session: SQLAlchemy 数据库会话。
+        """
         self.session = session
 
     def create(self, payload: DataItemCreate) -> DataItem:
+        """插入一条数据条目并返回刷新后的实例。
+
+        Args:
+            payload: 创建请求体。
+
+        Returns:
+            已持久化并刷新的 DataItem 实例。
+        """
         item = DataItem(**payload.model_dump())
         self.session.add(item)
         self.session.commit()
@@ -25,6 +44,16 @@ class DataItemRepository:
         limit: int = 50,
         offset: int = 0,
     ) -> list[DataItem]:
+        """分页查询未软删的数据条目。
+
+        Args:
+            namespace: 可选命名空间过滤条件。
+            limit: 单页最大条目数。
+            offset: 查询偏移量。
+
+        Returns:
+            当前页的 DataItem 实例列表。
+        """
         statement = select(DataItem).where(DataItem.deleted_at.is_(None))
         if namespace:
             statement = statement.where(DataItem.namespace == namespace)
@@ -51,6 +80,14 @@ class DataItemRepository:
         return self.session.scalar(statement) or 0
 
     def get(self, item_id: UUID) -> DataItem | None:
+        """按 ID 查询未软删的数据条目。
+
+        Args:
+            item_id: 数据条目唯一标识。
+
+        Returns:
+            命中的 DataItem 实例，不存在时返回 None。
+        """
         statement = select(DataItem).where(
             DataItem.id == item_id,
             DataItem.deleted_at.is_(None),
@@ -58,6 +95,15 @@ class DataItemRepository:
         return self.session.scalar(statement)
 
     def update(self, item: DataItem, payload: DataItemUpdate) -> DataItem:
+        """按显式字段更新数据条目。
+
+        Args:
+            item: 待更新的 DataItem 实例。
+            payload: 仅包含待更新字段的请求体。
+
+        Returns:
+            更新并刷新后的 DataItem 实例。
+        """
         update_data = payload.model_dump(exclude_unset=True)
         for key, value in update_data.items():
             setattr(item, key, value)
@@ -67,6 +113,11 @@ class DataItemRepository:
         return item
 
     def soft_delete(self, item: DataItem) -> None:
+        """软删除指定数据条目，写入 deleted_at 时间戳。
+
+        Args:
+            item: 待软删除的 DataItem 实例。
+        """
         item.deleted_at = datetime.now(UTC)
         self.session.add(item)
         self.session.commit()

--- a/backend-data/backend/app/services/cache_service.py
+++ b/backend-data/backend/app/services/cache_service.py
@@ -2,15 +2,30 @@ from app.core.redis_client import get_redis_client
 
 
 class CacheService:
+    """Redis 缓存业务编排层。
+
+    封装健康检查用测试键的写入与读取逻辑。
+    """
+
     test_key = "digital_employee:data_platform:test"
     test_value = "redis-ok"
 
     def write_test_key(self) -> dict:
+        """写入测试键，TTL 1 小时。
+
+        Returns:
+            写入的键名与对应值。
+        """
         client = get_redis_client()
         client.set(self.test_key, self.test_value, ttl_seconds=3600)
         return {"key": self.test_key, "value": self.test_value}
 
     def read_test_key(self) -> dict:
+        """读取测试键当前值。
+
+        Returns:
+            键名与读取到的值（键不存在时为 None）。
+        """
         client = get_redis_client()
         value = client.get(self.test_key)
         return {"key": self.test_key, "value": value}

--- a/backend-data/backend/app/services/data_item_service.py
+++ b/backend-data/backend/app/services/data_item_service.py
@@ -8,10 +8,28 @@ from app.schemas.data_item import DataItemCreate, DataItemUpdate
 
 
 class DataItemService:
+    """数据条目业务编排层。
+
+    封装数据条目的 CRUD 业务逻辑，对路由层屏蔽仓储细节。
+    """
+
     def __init__(self, repository: DataItemRepository) -> None:
+        """初始化服务并注入仓储实例。
+
+        Args:
+            repository: 数据条目仓储对象。
+        """
         self.repository = repository
 
     def create(self, payload: DataItemCreate) -> DataItem:
+        """创建一条新的数据条目。
+
+        Args:
+            payload: 创建请求体。
+
+        Returns:
+            持久化后的数据条目。
+        """
         return self.repository.create(payload)
 
     def list(
@@ -20,6 +38,16 @@ class DataItemService:
         limit: int = 50,
         offset: int = 0,
     ) -> list[DataItem]:
+        """分页查询数据条目列表。
+
+        Args:
+            namespace: 可选命名空间过滤条件，为 None 时不过滤。
+            limit: 单页最大条目数，默认 50。
+            offset: 查询偏移量，默认 0。
+
+        Returns:
+            当前页的数据条目列表。
+        """
         return self.repository.list(namespace=namespace, limit=limit, offset=offset)
 
     def list_with_count(
@@ -43,15 +71,40 @@ class DataItemService:
         return items, total
 
     def get(self, item_id: UUID) -> DataItem:
+        """按 ID 查询单条数据条目。
+
+        Args:
+            item_id: 数据条目唯一标识。
+
+        Returns:
+            对应的数据条目。
+
+        Raises:
+            HTTPException: 条目不存在时返回 404。
+        """
         item = self.repository.get(item_id)
         if item is None:
             raise HTTPException(status_code=404, detail="data item not found")
         return item
 
     def update(self, item_id: UUID, payload: DataItemUpdate) -> DataItem:
+        """更新指定数据条目。
+
+        Args:
+            item_id: 待更新条目唯一标识。
+            payload: 更新请求体，仅写入显式提供的字段。
+
+        Returns:
+            更新后的数据条目。
+        """
         item = self.get(item_id)
         return self.repository.update(item, payload)
 
     def delete(self, item_id: UUID) -> None:
+        """软删除指定数据条目。
+
+        Args:
+            item_id: 待删除条目唯一标识。
+        """
         item = self.get(item_id)
         self.repository.soft_delete(item)

--- a/backend-data/backend/app/services/health_service.py
+++ b/backend-data/backend/app/services/health_service.py
@@ -9,6 +9,14 @@ from app.schemas.health import DependencyStatus, DependenciesStatus
 
 
 def _measure(check: Callable[[], None]) -> DependencyStatus:
+    """执行一次依赖探活并测量耗时。
+
+    Args:
+        check: 具体的探活回调，发生异常时视为不可用。
+
+    Returns:
+        包含 ok 标志、消息与延迟毫秒数的状态对象。
+    """
     start = perf_counter()
     try:
         check()
@@ -20,24 +28,37 @@ def _measure(check: Callable[[], None]) -> DependencyStatus:
 
 
 def _check_database(role: DatabaseRole) -> None:
+    """对指定角色的 PostgreSQL 数据库执行一次 ping。"""
     get_database_client(role).ping()
 
 
 def _check_redis() -> None:
+    """对 Redis 实例执行一次 ping。"""
     client = get_redis_client()
     client.ping()
 
 
 def _check_minio() -> None:
+    """对 MinIO 实例执行 list_buckets 探活。"""
     client = get_minio_client()
     client.list_buckets()
 
 
 class HealthService:
+    """依赖健康检查业务编排层。"""
+
     def test_dependencies(
         self,
         target: ConnectionTarget = "all",
     ) -> DependenciesStatus:
+        """按目标维度执行依赖探活。
+
+        Args:
+            target: 探活目标，可选 all/postgres/core_db/vector_db/redis/minio。
+
+        Returns:
+            各依赖的探活状态汇总对象。
+        """
         enabled = {
             "core_db": target in {"all", "postgres", "core_db"},
             "vector_db": target in {"all", "postgres", "vector_db"},

--- a/backend-data/backend/app/services/storage_service.py
+++ b/backend-data/backend/app/services/storage_service.py
@@ -5,16 +5,36 @@ from app.core.minio_client import get_minio_client
 
 
 class StorageService:
+    """MinIO 对象存储业务编排层。
+
+    封装默认桶管理及健康检查对象的读写测试逻辑。
+    """
+
     test_object_name = "health-check/test-object.txt"
     test_object_content = b"minio-ok"
 
     def ensure_default_bucket(self) -> dict:
+        """确保默认存储桶存在，不存在则创建。
+
+        Returns:
+            桶名及存在性信息。
+        """
         return get_minio_client().ensure_bucket(settings.minio_default_bucket)
 
     def list_buckets(self) -> list[dict]:
+        """列出当前 MinIO 实例下的全部存储桶。
+
+        Returns:
+            桶名与创建时间组成的字典列表。
+        """
         return get_minio_client().list_buckets()
 
     def write_test_object(self) -> dict:
+        """写入用于健康检查的测试对象。
+
+        Returns:
+            桶名、对象名、可访问 URL 及写入内容。
+        """
         file_url = get_minio_client().upload_file(
             object_name=self.test_object_name,
             data=BytesIO(self.test_object_content),
@@ -29,6 +49,11 @@ class StorageService:
         }
 
     def read_test_object(self) -> dict:
+        """读取已写入的健康检查测试对象内容。
+
+        Returns:
+            桶名、对象名及读取到的文本内容。
+        """
         content = get_minio_client().download_file(
             object_name=self.test_object_name,
         ).read().decode("utf-8")


### PR DESCRIPTION
## 背景

PR #20 review 后指出 backend-data 存在无认证、文档暴露、HTTPException 泄漏等问题，本 PR 修复这些规范缺口。

## 改动清单

### 认证
- 新增 `app/api/deps.py`，提供 `verify_api_key` 依赖
- `router.py` 给非健康检查路由（system/data-items/storage/cache）统一挂载 `Depends(verify_api_key)`
- `config.py` 新增 `api_key` 配置项，留空时跳过校验

### 配置脱敏
- `config.py` 新增 `docs_enabled`，生产环境关闭 docs/redoc/openapi
- `main.py` 按 `docs_enabled` 控制文档站点暴露
- `public_config` 剔除 host/port/user/endpoint 等敏感字段，仅保留展示元信息

### 异常处理
- `main.py` HTTPException 处理器对 5xx 脱敏并日志记录，4xx 沿用 detail

### 文档规范
- 为 service/repository/health_service 补全 Google 风格 docstring
- README 技术栈修正为 Python 3.11+
- `.env.example` 增加 `API_KEY` 说明

## 验证

- 所有改动文件 `py_compile` 通过
- 不破坏现有 contract 测试
