### PR TITLE
fix(backend-gateway): 补齐 Admin 鉴权与代码规范

### DIFF
--- a/backend-gateway/.env.example
+++ b/backend-gateway/.env.example
@@ -29,3 +29,12 @@ MINIO_ACCESS_KEY=your_minio_access_key
 MINIO_SECRET_KEY=your_minio_secret_key
 # 系统默认读写存储桶 (需提前在控制台创建完毕)
 MINIO_BUCKET_NAME=your_file_bucket_name
+
+
+# ========================
+# Admin API 鉴权配置
+# ========================
+# 保护 /api/v1/admin/* 路由的 API Key。
+# 留空时跳过校验；生产环境务必配置。
+# 客户端需通过请求头 X-API-Key: <值> 携带。
+GATEWAY_ADMIN_API_KEY=

--- a/backend-gateway/src/core/base.py
+++ b/backend-gateway/src/core/base.py
@@ -60,6 +60,21 @@ class BaseBot(abc.ABC):
         """返回最近一次异常信息。"""
         return self._last_error
 
+    @property
+    def is_zombie(self) -> bool:
+        """判断 Bot 是否处于僵尸状态。
+
+        僵尸状态指 ``_is_running`` 标记为 True 但底层线程已不存在或已死亡，
+        需要由 Watchdog 重新拉起。该属性用于将 ``_is_running`` 与 ``_thread``
+        的访问收拢在 Bot 内部，避免管理器直接读取私有字段。
+
+        Returns:
+            True 表示 Bot 处于僵尸状态，需要重启；False 表示正常运行或已正常停止。
+        """
+        if not self._is_running:
+            return False
+        return self._thread is None or not self._thread.is_alive()
+
     def start(self) -> None:
         """启动 Bot 实例。
 

--- a/backend-gateway/src/core/hub.py
+++ b/backend-gateway/src/core/hub.py
@@ -13,6 +13,7 @@ from typing import Any, Callable
 
 import aio_pika
 from loguru import logger
+from pydantic import ValidationError
 
 from src.core.schemas import (
     MessageContent,
@@ -118,6 +119,8 @@ class MessageHub:
                 payload = json.loads(message.body.decode("utf-8"))
                 std_msg = StandardMessage(**payload)
                 await self.process_outbound(std_msg)
+            except (json.JSONDecodeError, ValidationError) as exc:
+                logger.error("[HUB-OUT] 出站消息解析失败: {}", exc)
             except Exception as exc:
                 logger.error("[HUB-OUT] 消费出站指令异常: {}", exc)
 

--- a/backend-gateway/src/main.py
+++ b/backend-gateway/src/main.py
@@ -6,10 +6,11 @@
 
 import asyncio
 import os
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
 import uvicorn
-from fastapi import FastAPI, HTTPException
+from fastapi import Depends, FastAPI, HTTPException
 
 from loguru import logger
 
@@ -20,6 +21,7 @@ from src.core.schemas import (
     HealthResponse,
 )
 from src.manager import BotManager
+from src.utils.auth import verify_admin_api_key
 from src.utils.rabbitmq import mq_client
 
 # 配置日志输出到文件
@@ -36,7 +38,7 @@ manager: BotManager = BotManager(config_path="config/bot.json")
 
 
 @asynccontextmanager
-async def lifespan(app: FastAPI):
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     """FastAPI 生命周期管理上下文。
 
     启动时完成以下初始化序列：
@@ -117,7 +119,11 @@ async def get_health() -> HealthResponse:
     )
 
 
-@app.get("/api/v1/admin/bots", response_model=list[BotStatusResponse])
+@app.get(
+    "/api/v1/admin/bots",
+    response_model=list[BotStatusResponse],
+    dependencies=[Depends(verify_admin_api_key)],
+)
 async def get_bots() -> list[BotStatusResponse]:
     """获取所有 Bot 实例当前的运行详情。
 
@@ -127,7 +133,10 @@ async def get_bots() -> list[BotStatusResponse]:
     return manager.get_all_status()
 
 
-@app.post("/api/v1/admin/bots")
+@app.post(
+    "/api/v1/admin/bots",
+    dependencies=[Depends(verify_admin_api_key)],
+)
 async def add_or_update_bot(req: BotConfigRequest) -> dict[str, str]:
     """动态添加或更新 Bot 凭证。
 
@@ -150,7 +159,10 @@ async def add_or_update_bot(req: BotConfigRequest) -> dict[str, str]:
     return {"status": "success", "message": f"Bot {req.bot_id} has been added or updated"}
 
 
-@app.delete("/api/v1/admin/bots/{bot_id}")
+@app.delete(
+    "/api/v1/admin/bots/{bot_id}",
+    dependencies=[Depends(verify_admin_api_key)],
+)
 async def delete_bot(bot_id: str) -> dict[str, str]:
     """销毁并注销指定的 Bot 实例，断开其与平台的长连接。
 

--- a/backend-gateway/src/manager.py
+++ b/backend-gateway/src/manager.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from loguru import logger
+from pydantic import ValidationError
 
 from src.core.base import BaseBot
 from src.core.schemas import BotConfig, BotConfigFile, BotStatusResponse
@@ -72,8 +73,12 @@ class BotManager:
             for bot_cfg in config_file.bots:
                 self.add_or_update_bot(bot_cfg)
 
+        except (json.JSONDecodeError, ValidationError) as exc:
+            logger.error("静态配置文件 {} 解析失败: {}", self.config_path, exc)
+        except OSError as exc:
+            logger.error("读取静态配置文件 {} 失败: {}", self.config_path, exc)
         except Exception as exc:
-            logger.error("加载静态配置文件失败: {}", exc)
+            logger.error("加载静态配置文件时发生未预期异常: {}", exc)
 
     def inject_main_loop_to_all(self, loop: asyncio.AbstractEventLoop) -> None:
         """将 FastAPI 主事件循环注入给所有已加载的 Bot 实例。
@@ -242,17 +247,14 @@ class BotManager:
 
             with self._lock:
                 for bot_id, bot in self.bots.items():
-                    # 如果 Bot 标记为应该运行，但对应的底层线程已经死掉
-                    if bot._is_running and (
-                        bot._thread is None or not bot._thread.is_alive()
-                    ):
+                    # 通过公开属性判断是否处于僵尸状态，避免直接读取私有字段
+                    if bot.is_zombie:
                         logger.warning(
                             "[BotID: {}] 检测到 Bot 线程异常终止（僵尸状态），正在尝试重新拉起...",
                             bot_id,
                         )
                         try:
-                            # 清理残留线程对象，重新拉起
-                            bot._thread = None
+                            # start() 会重置 _thread，无需外部清理私有字段
                             bot.start()
                         except Exception as exc:
                             logger.error(

--- a/backend-gateway/src/utils/auth.py
+++ b/backend-gateway/src/utils/auth.py
@@ -5,6 +5,7 @@
 """
 
 import os
+import secrets
 
 from fastapi import Header, HTTPException
 
@@ -17,6 +18,8 @@ async def verify_admin_api_key(
     当环境变量 ``GATEWAY_ADMIN_API_KEY`` 未配置时跳过校验，便于本地开发；
     生产环境应通过环境变量显式配置，以保护 Admin 接口。
 
+    使用 ``secrets.compare_digest`` 进行常量时间比较，避免时序攻击。
+
     Args:
         x_api_key: 请求头 ``X-API-Key`` 的值，缺失或为空表示未携带。
 
@@ -27,5 +30,5 @@ async def verify_admin_api_key(
     expected = os.getenv("GATEWAY_ADMIN_API_KEY", "").strip()
     if not expected:
         return
-    if x_api_key != expected:
+    if not x_api_key or not secrets.compare_digest(x_api_key, expected):
         raise HTTPException(status_code=401, detail="invalid api key")

--- a/backend-gateway/src/utils/auth.py
+++ b/backend-gateway/src/utils/auth.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+"""Admin API 鉴权依赖。
+
+为 ``/api/v1/admin/*`` 路由提供轻量 API Key 校验，避免 Bot 凭证被未授权读写。
+"""
+
+import os
+
+from fastapi import Header, HTTPException
+
+
+async def verify_admin_api_key(
+    x_api_key: str | None = Header(default=None),
+) -> None:
+    """校验请求头 ``X-API-Key`` 是否与服务端配置一致。
+
+    当环境变量 ``GATEWAY_ADMIN_API_KEY`` 未配置时跳过校验，便于本地开发；
+    生产环境应通过环境变量显式配置，以保护 Admin 接口。
+
+    Args:
+        x_api_key: 请求头 ``X-API-Key`` 的值，缺失或为空表示未携带。
+
+    Raises:
+        HTTPException: 当 ``GATEWAY_ADMIN_API_KEY`` 已配置但请求头缺失或不匹配时，
+            返回 401 未授权。
+    """
+    expected = os.getenv("GATEWAY_ADMIN_API_KEY", "").strip()
+    if not expected:
+        return
+    if x_api_key != expected:
+        raise HTTPException(status_code=401, detail="invalid api key")


### PR DESCRIPTION
## 背景

PR #20 review 后指出 backend-gateway 的 Admin 接口无认证、lifespan 缺类型注解、Watchdog 直读私有属性、异常捕获过宽，本 PR 修复这些问题。

## 改动清单

### Admin 鉴权
- 新增 `src/utils/auth.py`，提供 `verify_admin_api_key` 依赖
- `main.py` 给 `/api/v1/admin/bots` 三个端点挂载 `Depends(verify_admin_api_key)`
- `.env.example` 增加 `GATEWAY_ADMIN_API_KEY` 说明

### 类型与封装
- `main.py` lifespan 补 `AsyncIterator[None]` 返回类型注解
- `BaseBot` 新增 `is_zombie` 公开属性，封装僵尸态判断
- `manager._watchdog_loop` 改用 `bot.is_zombie`，避免直接读取 `_is_running` 与 `_thread`

### 异常收窄
- `manager.load_from_file` 按 `OSError` / `JSONDecodeError` / `ValidationError` 分类捕获
- `hub.consume_outbound` 拆分解析异常与通用异常分支

## 验证

- `auth` / `base` / `hub` 导入验证通过
- 所有改动文件 `py_compile` 通过
