### PR TITLE
fix: 修复侧边栏菜单展开与数据中台根路径信封

### DIFF
--- a/backend-data/backend/app/main.py
+++ b/backend-data/backend/app/main.py
@@ -9,8 +9,9 @@ from loguru import logger
 
 from app.api.router import api_router
 from app.core.config import settings
+from app.schemas.common import ApiResponse
 from app.schemas.health import ServiceInfo
-from app.utils.response import fail_response
+from app.utils.response import fail_response, success_response
 
 
 @asynccontextmanager
@@ -85,13 +86,15 @@ async def unhandled_exception_handler(request: Request, exc: Exception) -> JSONR
     )
 
 
-@app.get("/", response_model=ServiceInfo)
-def root() -> ServiceInfo:
-    return ServiceInfo(
-        name=settings.app_name,
-        version=settings.app_version,
-        environment=settings.app_env,
-        status="running",
+@app.get("/", response_model=ApiResponse)
+def root() -> dict:
+    return success_response(
+        ServiceInfo(
+            name=settings.app_name,
+            version=settings.app_version,
+            environment=settings.app_env,
+            status="running",
+        ).model_dump()
     )
 
 

--- a/frontend/src/components/Layout/components/SiderMenu.tsx
+++ b/frontend/src/components/Layout/components/SiderMenu.tsx
@@ -1,6 +1,12 @@
 import { Layout, Menu } from 'antd';
-import { AppstoreOutlined, BuildOutlined, DatabaseOutlined, DashboardOutlined, SettingOutlined, TableOutlined } from '@ant-design/icons';
-import { useState } from 'react';
+import {
+  AppstoreOutlined,
+  BuildOutlined,
+  DatabaseOutlined,
+  DashboardOutlined,
+  SettingOutlined,
+  TableOutlined,
+} from '@ant-design/icons';
 import { useNavigate, useLocation } from 'react-router-dom';
 import logo from '@/assets/images/avatar/logo.svg';
 import styles from '../index.module.css';
@@ -13,16 +19,9 @@ export default function SiderMenu(): React.ReactElement {
   const navigate = useNavigate();
   const location = useLocation();
 
-  // 用户显式收起时优先级高于路由强制展开：在 data-platform 页面用户仍可手动折叠子菜单
-  // 路由变化时（导航到 data-platform）自动展开，除非用户已手动收起
-  const [dpManuallyClosed, setDpManuallyClosed] = useState<boolean>(false);
-  const isOnDataPlatform = location.pathname.startsWith('/data-platform');
-  const shouldOpen = (isOnDataPlatform && !dpManuallyClosed);
-  const openKeys = shouldOpen ? [DATA_PLATFORM_KEY] : [];
-
-  const handleOpenChange = (keys: string[]): void => {
-    setDpManuallyClosed(!keys.includes(DATA_PLATFORM_KEY));
-  };
+  // 常规菜单树模式：非受控展开，Menu 内部自管理 openKeys。
+  // 默认展开所有父菜单，之后完全由用户点击展开/折叠。
+  const defaultOpenKeys = [DATA_PLATFORM_KEY];
 
   const menuItems = [
     { key: '/', icon: <AppstoreOutlined />, label: '页面 A' },
@@ -51,9 +50,12 @@ export default function SiderMenu(): React.ReactElement {
         theme="dark"
         mode="inline"
         selectedKeys={selectedKeys}
-        openKeys={openKeys}
-        onOpenChange={handleOpenChange}
-        onClick={({ key }) => navigate(key)}
+        defaultOpenKeys={defaultOpenKeys}
+        onClick={({ key }) => {
+          // 父菜单（含 children）仅负责展开/折叠，不触发路由跳转
+          if (key === DATA_PLATFORM_KEY) return;
+          navigate(key);
+        }}
         items={menuItems}
       />
     </Sider>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -18,6 +18,8 @@ export default defineConfig(({ mode }) => {
       alias: [{ find: '@', replacement: path.resolve(__dirname, 'src') }],
     },
     server: {
+      port: 5173,
+      strictPort: true,
       proxy: {
         // backend-agent，开发环境通过代理转发避免跨域
         '/backend-agent-api': {


### PR DESCRIPTION
- 侧边栏菜单改为常规树形交互：默认展开父菜单，点击父菜单仅切换展开/折叠不导航
- 后端根路径返回标准 {success, message, data} 信封，与其它端点一致
- 前端开发端口锁定为 5173，端口占用时报错而非静默切换到 5174