### PR TITLE
fix: 完善项目一键启动与依赖验收

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,9 @@ digital-employee/
 scripts\start-all.bat
 
 # 或单独启动某个服务
-scripts\backend-gateway\start.bat
 scripts\data-platform\start.bat
+scripts\backend-auth\start.bat
+scripts\backend-gateway\start.bat
 scripts\frontend\start-web.bat
 ```
 
@@ -96,15 +97,18 @@ scripts\frontend\start-web.bat
 ./scripts/start-all.sh
 
 # 或单独启动某个服务
-./scripts/backend-gateway/start.sh
 ./scripts/data-platform/start.sh
+./scripts/backend-auth/start.sh
+./scripts/backend-gateway/start.sh
 ./scripts/frontend/start-web.sh
 ```
 
 启动脚本会自动：
 1. 复制 `.env.example` → `.env`（首次启动）
-2. 安装前端依赖（首次启动）
-3. 启动服务并打印健康检查地址
+2. 清理 `8010`、`8020`、`8864`、`5173` 上的旧项目进程
+3. 按 `backend-data` → `backend-auth` → `backend-gateway` → `frontend` 顺序启动
+4. 注入统一的服务间 API Key，并验证基础设施依赖与消息中间件拓扑
+5. 任一服务或依赖未就绪时结束本次启动并清理已启动进程
 
 > **注意**：启动脚本需要 `uv` 在 PATH 中。Windows 安装 uv：`pip install uv`；其他平台见 [uv 官方文档](https://docs.astral.sh/uv/)。
 
@@ -124,8 +128,14 @@ uv sync
 Copy-Item .env.example .env
 uv run uvicorn app.main:app --host 0.0.0.0 --port 8010
 
+# backend-auth
+cd ..\..\backend-auth
+uv sync
+Copy-Item .env.example .env
+uv run uvicorn app.main:app --host 0.0.0.0 --port 8020
+
 # frontend
-cd frontend
+cd ..\frontend
 npm ci
 npm run dev
 ```

--- a/scripts/backend-auth/start.bat
+++ b/scripts/backend-auth/start.bat
@@ -1,0 +1,18 @@
+@echo off
+chcp 65001 >nul
+
+title Backend Auth Service
+cd /d "%~dp0..\..\backend-auth"
+
+if not exist ".env" if exist ".env.example" copy ".env.example" ".env" >nul
+
+echo ===================================================
+echo            Backend Auth Service 8020
+echo ===================================================
+echo [INFO] Starting Backend Auth Service with uv...
+echo   - Local URL: http://localhost:8020
+echo   - Health Check: http://localhost:8020/api/v1/health
+echo ===================================================
+
+uv run uvicorn app.main:app --host 127.0.0.1 --port 8020
+pause

--- a/scripts/backend-auth/start.sh
+++ b/scripts/backend-auth/start.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+PROJECT_ROOT="$REPO_ROOT/backend-auth"
+
+command -v uv >/dev/null 2>&1 || {
+  echo "[ERROR] 未找到 uv，请先安装: https://docs.astral.sh/uv/" >&2
+  exit 1
+}
+
+if [[ ! -f "$PROJECT_ROOT/.env" && -f "$PROJECT_ROOT/.env.example" ]]; then
+  cp "$PROJECT_ROOT/.env.example" "$PROJECT_ROOT/.env"
+fi
+
+echo "[INFO] 启动认证服务 (http://localhost:8020)..."
+cd "$PROJECT_ROOT"
+exec uv run uvicorn app.main:app --host 127.0.0.1 --port 8020 "$@"

--- a/scripts/kill-port.py
+++ b/scripts/kill-port.py
@@ -70,6 +70,8 @@ def _find_pids_windows(port: int) -> set[str]:
         parts = line.split()
         if len(parts) < 5:
             continue
+        if parts[0].upper() == "TCP" and parts[3].upper() != "LISTENING":
+            continue
         local_addr = parts[1]
         if not local_addr.endswith(suffix):
             continue
@@ -81,7 +83,7 @@ def _find_pids_windows(port: int) -> set[str]:
 
 def _find_pids_unix(port: int) -> set[str]:
     """Unix 下通过 lsof 获取占用端口的 PID 集合。"""
-    stdout, _ = _run(["lsof", "-i", f":{port}", "-t"])
+    stdout, _ = _run(["lsof", "-nP", f"-iTCP:{port}", "-sTCP:LISTEN", "-t"])
     pids: set[str] = set()
     for line in stdout.splitlines():
         line = line.strip()

--- a/scripts/start-all.bat
+++ b/scripts/start-all.bat
@@ -7,27 +7,11 @@ echo ===================================================
 echo.
 
 set SCRIPT_DIR=%~dp0
-for %%I in ("%SCRIPT_DIR%..") do set PROJECT_ROOT=%%~fI
-
-echo [INFO] Step 1/4: Cleaning python __pycache__...
-if exist "%SCRIPT_DIR%clean-pycache.py" (
-    where uv >nul 2>&1 && uv run python "%SCRIPT_DIR%clean-pycache.py" 2>nul || python "%SCRIPT_DIR%clean-pycache.py" 2>nul
+where uv >nul 2>&1
+if errorlevel 1 (
+    echo [ERROR] uv was not found in PATH.
+    exit /b 1
 )
-echo.
 
-echo [INFO] Step 2/4: Starting Backend Gateway Service (8864)...
-start "Backend-Gateway-Service" cmd /k "%SCRIPT_DIR%backend-gateway\start.bat"
-
-echo [INFO] Step 3/4: Starting Backend Data Service (8010)...
-start "Backend-Data-Service" cmd /k "%SCRIPT_DIR%data-platform\start.bat"
-
-echo [INFO] Step 4/4: Starting Frontend Dev Server (5173)...
-start "Frontend-Dev-Server" cmd /k "%SCRIPT_DIR%frontend\start-web.bat"
-
-echo.
-echo ===================================================
-echo   All service launch commands sent successfully!
-echo   Check real-time logs in each opened console window.
-echo ===================================================
-echo.
-pause
+uv run python "%SCRIPT_DIR%start-all.py"
+exit /b %errorlevel%

--- a/scripts/start-all.py
+++ b/scripts/start-all.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""跨平台启动数字员工项目的全部运行服务。"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from hashlib import sha256
+from pathlib import Path
+from urllib.error import URLError
+from urllib.request import Request, urlopen
+
+LOGGER = logging.getLogger("start-all")
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+SERVICE_PORTS = (8010, 8020, 8864, 5173)
+HEALTH_ATTEMPTS = 40
+HEALTH_INTERVAL_SECONDS = 0.5
+HEALTH_TIMEOUT_SECONDS = 2.0
+
+
+@dataclass(frozen=True)
+class ServiceSpec:
+    """描述一个由一键脚本管理的项目服务。"""
+
+    name: str
+    working_directory: Path
+    command: tuple[str, ...]
+    health_url: str
+    environment: dict[str, str]
+
+
+@dataclass(frozen=True)
+class EndpointCheck:
+    """描述启动后的 HTTP 验收请求。"""
+
+    name: str
+    url: str
+    headers: dict[str, str]
+    method: str = "GET"
+    body: bytes | None = None
+
+
+def _read_env_file(path: Path) -> dict[str, str]:
+    """读取简单 dotenv 文件，不执行变量展开。"""
+    values: dict[str, str] = {}
+    if not path.exists():
+        return values
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        normalized_value = value.strip()
+        if (
+            len(normalized_value) >= 2
+            and normalized_value[0] == normalized_value[-1]
+            and normalized_value[0] in {'"', "'"}
+        ):
+            normalized_value = normalized_value[1:-1]
+        values[key.strip()] = normalized_value
+    return values
+
+
+def _ensure_env_file(project_directory: Path) -> Path:
+    """确保项目存在本地 .env，并返回其路径。"""
+    env_path = project_directory / ".env"
+    if env_path.exists():
+        return env_path
+    example_path = project_directory / ".env.example"
+    if not example_path.exists():
+        raise RuntimeError(f"缺少配置文件：{env_path}")
+    shutil.copyfile(example_path, env_path)
+    LOGGER.info("已从示例创建配置文件：%s", env_path)
+    return env_path
+
+
+def _resolve_command(name: str, *, windows_name: str | None = None) -> str:
+    """解析必需的可执行文件路径。"""
+    candidate = windows_name if sys.platform == "win32" and windows_name else name
+    executable = shutil.which(candidate)
+    if executable is None:
+        raise RuntimeError(f"未找到必需命令：{candidate}")
+    return executable
+
+
+def _build_environment(
+    env_file: Path,
+    *,
+    overrides: dict[str, str] | None = None,
+) -> dict[str, str]:
+    """构造服务子进程环境，显式配置优先于父进程环境。"""
+    environment = dict(os.environ)
+    environment.update(_read_env_file(env_file))
+    if overrides:
+        environment.update(overrides)
+    return environment
+
+
+def _build_service_specs() -> list[ServiceSpec]:
+    """构造按依赖顺序排列的服务定义。"""
+    uv = _resolve_command("uv")
+    npm = _resolve_command("npm", windows_name="npm.cmd")
+    data_dir = PROJECT_ROOT / "backend-data" / "backend"
+    auth_dir = PROJECT_ROOT / "backend-auth"
+    gateway_dir = PROJECT_ROOT / "backend-gateway"
+    frontend_dir = PROJECT_ROOT / "frontend"
+    data_env_file = _ensure_env_file(data_dir)
+    auth_env_file = _ensure_env_file(auth_dir)
+    gateway_env_file = _ensure_env_file(gateway_dir)
+    frontend_env_file = _ensure_env_file(frontend_dir)
+    if not (frontend_dir / "node_modules").exists():
+        LOGGER.info("Frontend 依赖不存在，正在执行 npm install...")
+        install_result = subprocess.run(
+            (npm, "install"),
+            cwd=frontend_dir,
+            check=False,
+        )
+        if install_result.returncode != 0:
+            raise RuntimeError("Frontend 依赖安装失败")
+    service_api_key = _read_env_file(data_env_file).get("API_KEY", "").strip()
+    if not service_api_key:
+        raise RuntimeError("backend-data/.env 中的 API_KEY 未配置，无法安全启动服务")
+    data_client_overrides = {"BACKEND_DATA_API_KEY": service_api_key}
+
+    return [
+        ServiceSpec(
+            name="Backend Data",
+            working_directory=data_dir,
+            command=(uv, "run", "uvicorn", "app.main:app", "--host", "127.0.0.1", "--port", "8010"),
+            health_url="http://127.0.0.1:8010/api/v1/health",
+            environment=_build_environment(data_env_file),
+        ),
+        ServiceSpec(
+            name="Backend Auth",
+            working_directory=auth_dir,
+            command=(uv, "run", "uvicorn", "app.main:app", "--host", "127.0.0.1", "--port", "8020"),
+            health_url="http://127.0.0.1:8020/api/v1/health",
+            environment=_build_environment(
+                auth_env_file,
+                overrides=data_client_overrides,
+            ),
+        ),
+        ServiceSpec(
+            name="Backend Gateway",
+            working_directory=gateway_dir,
+            command=(uv, "run", "uvicorn", "src.main:app", "--host", "127.0.0.1", "--port", "8864"),
+            health_url="http://127.0.0.1:8864/api/v1/health",
+            environment=_build_environment(
+                gateway_env_file,
+                overrides=data_client_overrides,
+            ),
+        ),
+        ServiceSpec(
+            name="Frontend",
+            working_directory=frontend_dir,
+            command=(npm, "run", "dev", "--", "--host", "127.0.0.1", "--port", "5173"),
+            health_url="http://127.0.0.1:5173",
+            environment=_build_environment(frontend_env_file),
+        ),
+    ]
+
+
+def _clean_project_ports() -> None:
+    """调用仓库端口工具清理旧服务进程。"""
+    command = [
+        sys.executable,
+        str(PROJECT_ROOT / "scripts" / "kill-port.py"),
+        *(str(port) for port in SERVICE_PORTS),
+    ]
+    result = subprocess.run(command, check=False)
+    if result.returncode != 0:
+        raise RuntimeError("旧服务端口清理失败")
+
+
+def _start_service(service: ServiceSpec) -> subprocess.Popen[bytes]:
+    """在独立进程会话中启动服务。"""
+    kwargs: dict[str, object] = {
+        "cwd": service.working_directory,
+        "env": service.environment,
+    }
+    if sys.platform == "win32":
+        kwargs["creationflags"] = subprocess.CREATE_NEW_CONSOLE
+    else:
+        kwargs["start_new_session"] = True
+    return subprocess.Popen(service.command, **kwargs)  # type: ignore[arg-type]
+
+
+def _request_endpoint(check: EndpointCheck) -> tuple[int, object | None]:
+    """请求验收端点并返回 HTTP 状态码与 JSON 响应。"""
+    request = Request(  # noqa: S310
+        check.url,
+        data=check.body,
+        headers=check.headers,
+        method=check.method,
+    )
+    with urlopen(  # noqa: S310
+        request,
+        timeout=HEALTH_TIMEOUT_SECONDS,
+    ) as response:
+        body = response.read()
+        if not body:
+            return response.status, None
+        try:
+            return response.status, json.loads(body)
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return response.status, None
+
+
+def _wait_for_health(service: ServiceSpec, process: subprocess.Popen[bytes]) -> None:
+    """等待服务健康检查通过，否则抛出启动失败。"""
+    for _ in range(HEALTH_ATTEMPTS):
+        if process.poll() is not None:
+            raise RuntimeError(
+                f"{service.name} 进程提前退出，退出码：{process.returncode}"
+            )
+        try:
+            status, _ = _request_endpoint(
+                EndpointCheck(
+                    name=service.name,
+                    url=service.health_url,
+                    headers={},
+                )
+            )
+            if 200 <= status < 400:
+                LOGGER.info("%s 已就绪：%s", service.name, service.health_url)
+                return
+        except (OSError, URLError):
+            pass
+        time.sleep(HEALTH_INTERVAL_SECONDS)
+    raise RuntimeError(f"{service.name} 健康检查超时：{service.health_url}")
+
+
+def _verify_service_dependencies(service_api_key: str) -> None:
+    """验证受保护依赖探活和消息中间件拓扑。"""
+    headers = {"X-API-Key": service_api_key}
+    checks = (
+        EndpointCheck(
+            name="Backend Data dependencies",
+            url="http://127.0.0.1:8010/api/v1/health/dependencies",
+            headers=headers,
+        ),
+        EndpointCheck(
+            name="Message broker topology",
+            url="http://127.0.0.1:8010/api/v1/infrastructure/message-broker/topology",
+            headers=headers,
+            method="POST",
+        ),
+        EndpointCheck(
+            name="Redis rate-limit transaction",
+            url="http://127.0.0.1:8010/api/v1/identity/auth/rate-limit/consume",
+            headers={**headers, "Content-Type": "application/json"},
+            method="POST",
+            body=json.dumps(
+                {
+                    "bucket": "startup-verification",
+                    "identifier_hash": sha256(
+                        b"digital-employee-startup"
+                    ).hexdigest(),
+                    "limit": 10000,
+                    "window_seconds": 60,
+                },
+                separators=(",", ":"),
+            ).encode("utf-8"),
+        ),
+    )
+    for check in checks:
+        try:
+            status, body = _request_endpoint(check)
+        except (OSError, URLError) as exc:
+            raise RuntimeError(f"{check.name} 验收失败") from exc
+        if not 200 <= status < 400:
+            raise RuntimeError(f"{check.name} 验收返回 HTTP {status}")
+        if not isinstance(body, dict) or body.get("success") is not True:
+            raise RuntimeError(f"{check.name} 未返回成功响应")
+        if check.name == "Backend Data dependencies":
+            dependency_data = body.get("data")
+            if not isinstance(dependency_data, dict) or any(
+                not isinstance(status_data, dict)
+                or status_data.get("ok") is not True
+                for status_data in dependency_data.values()
+            ):
+                raise RuntimeError("Backend Data 存在未就绪依赖")
+        LOGGER.info("%s 验收通过", check.name)
+
+
+def main() -> int:
+    """清理旧进程，按依赖顺序启动并验证全部服务。"""
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    try:
+        services = _build_service_specs()
+        _clean_project_ports()
+        for service in services:
+            LOGGER.info("正在启动 %s...", service.name)
+            process = _start_service(service)
+            _wait_for_health(service, process)
+        service_api_key = services[0].environment["API_KEY"]
+        _verify_service_dependencies(service_api_key)
+    except (OSError, RuntimeError) as exc:
+        LOGGER.error("一键启动失败：%s", exc)
+        try:
+            _clean_project_ports()
+        except (OSError, RuntimeError):
+            pass
+        return 1
+
+    LOGGER.info("全部服务启动成功：")
+    for service in services:
+        LOGGER.info("- %s: %s", service.name, service.health_url)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/start-all.sh
+++ b/scripts/start-all.sh
@@ -2,68 +2,10 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 command -v uv >/dev/null 2>&1 || {
   echo "[ERROR] 未找到 uv，请先安装: https://docs.astral.sh/uv/" >&2
   exit 1
 }
 
-# 健康检查轮询：等待指定 URL 返回 2xx，超时后打 warning 但不阻断后续步骤
-# （服务可能因依赖缺失启动失败，由用户根据日志排查）
-wait_for_health() {
-  local name="$1"
-  local url="$2"
-  local max_attempts="${3:-15}"
-  local attempt=0
-  while (( attempt < max_attempts )); do
-    if curl -fsS "$url" >/dev/null 2>&1; then
-      echo "[OK] $name 已就绪"
-      return 0
-    fi
-    attempt=$((attempt + 1))
-    sleep 2
-  done
-  echo "[WARN] $name 在 $((max_attempts * 2))s 内未就绪，请查看日志排查"
-  return 1
-}
-
-echo "==================================================="
-echo "  Digital Employee - 一键启动所有服务"
-echo "==================================================="
-echo ""
-
-echo "[INFO] 步骤 1/4: 清理全项目 Python 缓存..."
-uv run python "$SCRIPT_DIR/clean-pycache.py" || true
-echo ""
-
-echo "[INFO] 步骤 2/4: 启动 Backend Gateway 网关服务 (8864)..."
-if [ -f "$SCRIPT_DIR/backend-gateway/start.sh" ]; then
-    bash "$SCRIPT_DIR/backend-gateway/start.sh" &
-    GATEWAY_PID=$!
-    echo "Backend Gateway shell PID: $GATEWAY_PID"
-    wait_for_health "Backend Gateway" "http://localhost:8864/api/v1/health" 10 || true
-fi
-
-echo "[INFO] 步骤 3/4: 启动 Backend Data 数据中台服务 (8010)..."
-if [ -f "$SCRIPT_DIR/data-platform/start.sh" ]; then
-    bash "$SCRIPT_DIR/data-platform/start.sh" &
-    # 注意：data-platform/start.sh 内部用 nohup 后台启动 uvicorn 后立即退出，
-    # 此处 $! 是 bash 子 shell PID 而非 uvicorn 进程 PID，仅用于 start-all 退出码跟踪
-    DATA_SHELL_PID=$!
-    echo "Backend Data shell PID: $DATA_SHELL_PID"
-    wait_for_health "Backend Data" "http://localhost:8010/api/v1/health" 15 || true
-fi
-
-echo "[INFO] 步骤 4/4: 启动 Frontend 前端开发服务 (5173)..."
-bash "$SCRIPT_DIR/frontend/start-web.sh" &
-FRONTEND_PID=$!
-echo "Frontend Dev Server PID: $FRONTEND_PID"
-
-echo ""
-echo "==================================================="
-echo "  所有后台服务已拉起！"
-echo "  - Backend Gateway: http://localhost:8864"
-echo "  - Backend Data:    http://localhost:8010"
-echo "  - Frontend Dev:    http://localhost:5173"
-echo "==================================================="
+exec uv run python "$SCRIPT_DIR/start-all.py"


### PR DESCRIPTION
## 修改内容

- 新增跨平台统一启动器，按 `backend-data -> backend-auth -> backend-gateway -> frontend` 的依赖顺序启动四个服务。
- 补齐 backend-auth 的 Windows/Linux 单服务启动入口。
- 从 backend-data 本地配置读取服务间 API Key，并仅通过子进程环境变量注入 auth/gateway，避免输出或提交密钥。
- 启动后验证服务健康、backend-data 基础设施依赖、RabbitMQ topology 与 Redis 限流事务。
- 任一启动或依赖验收失败时返回非零并清理已启动的项目端口。
- 端口清理仅处理监听进程，避免误杀临时客户端连接。

## 根因

原一键启动脚本遗漏 backend-auth，且启动顺序与服务依赖不一致；gateway 未获得 backend-data API Key 会产生 401；Redis ACL 缺少 `WATCH` 权限时，限流事务会在运行期返回 500，但旧脚本无法识别这些半启动状态。

## 验证

- `scripts\start-all.bat`：四服务启动成功，退出码 0。
- backend-data dependencies、MQ topology、Redis rate-limit transaction：全部验收通过。
- 四个健康地址与前端首页：全部 HTTP 200。
- 前端代理登录探针：返回业务 401 `INVALID_CREDENTIALS`，未再出现 Redis 500。
- `npm run build`：通过（仅既有 chunk size 提示）。
- Ruff、Python compileall、`git diff --check`：通过。

> Linux shell 入口已完成代码审查；当前 Windows 环境无可用 Linux/WSL 运行时，未执行 Linux 实机启动。