### PR TITLE
fix(auth): 认证服务不可用兜底 + 错误提示统一携带 traceId

### DIFF
--- a/frontend/src/components/Layout/components/MainContent.tsx
+++ b/frontend/src/components/Layout/components/MainContent.tsx
@@ -2,10 +2,7 @@ import { Button, Layout, Result } from 'antd';
 import { Outlet, useLocation } from 'react-router';
 import styles from '../index.module.css';
 import { PageLoading } from '@/components/page-loading/PageLoading';
-import {
-  AUTH_SERVICE_UNAVAILABLE_MESSAGE,
-  useUserStore,
-} from '@/store/user-store';
+import { useUserStore } from '@/store/user-store';
 
 const { Content } = Layout;
 
@@ -14,6 +11,7 @@ export default function MainContent(): React.ReactElement {
   const userInfo = useUserStore((state) => state.userInfo);
   const profileLoading = useUserStore((state) => state.profileLoading);
   const profileError = useUserStore((state) => state.profileError);
+  const profileErrorKind = useUserStore((state) => state.profileErrorKind);
   const hydrateCurrentUser = useUserStore((state) => state.hydrateCurrentUser);
   const isDataPlatformPage = location.pathname.startsWith('/data-platform/');
   const contentClassName = isDataPlatformPage
@@ -26,10 +24,10 @@ export default function MainContent(): React.ReactElement {
   if (!userInfo && profileLoading) {
     pageContent = <PageLoading label="正在加载用户信息" />;
   } else if (!userInfo && profileError) {
-    // 服务不可用（连接被拒绝/超时/5xx）：用 warning 状态引导用户重试连接；
-    // 其他业务错误（如权限不足）用 error 状态，引导重新加载。
-    const isServiceUnavailable =
-      profileError === AUTH_SERVICE_UNAVAILABLE_MESSAGE;
+    // 按结构化 errorKind 分支（替代字符串匹配），文案调整或追加 traceId 不会影响判别：
+    //   - service-unavailable（连接被拒绝/超时/5xx）：warning 状态，引导重试连接服务；
+    //   - business（如权限不足/用户被禁用）：error 状态，引导重新加载。
+    const isServiceUnavailable = profileErrorKind === 'service-unavailable';
     pageContent = (
       <Result
         status={isServiceUnavailable ? 'warning' : 'error'}

--- a/frontend/src/components/Layout/components/MainContent.tsx
+++ b/frontend/src/components/Layout/components/MainContent.tsx
@@ -2,7 +2,10 @@ import { Button, Layout, Result } from 'antd';
 import { Outlet, useLocation } from 'react-router';
 import styles from '../index.module.css';
 import { PageLoading } from '@/components/page-loading/PageLoading';
-import { useUserStore } from '@/store/user-store';
+import {
+  AUTH_SERVICE_UNAVAILABLE_MESSAGE,
+  useUserStore,
+} from '@/store/user-store';
 
 const { Content } = Layout;
 
@@ -23,17 +26,21 @@ export default function MainContent(): React.ReactElement {
   if (!userInfo && profileLoading) {
     pageContent = <PageLoading label="正在加载用户信息" />;
   } else if (!userInfo && profileError) {
+    // 服务不可用（连接被拒绝/超时/5xx）：用 warning 状态引导用户重试连接；
+    // 其他业务错误（如权限不足）用 error 状态，引导重新加载。
+    const isServiceUnavailable =
+      profileError === AUTH_SERVICE_UNAVAILABLE_MESSAGE;
     pageContent = (
       <Result
-        status="warning"
-        title="用户信息加载失败"
+        status={isServiceUnavailable ? 'warning' : 'error'}
+        title={isServiceUnavailable ? '认证服务暂时不可用' : '用户信息加载失败'}
         subTitle={profileError}
         extra={(
           <Button
             type="primary"
             onClick={() => void hydrateCurrentUser()}
           >
-            重新加载
+            {isServiceUnavailable ? '重试连接服务' : '重新加载'}
           </Button>
         )}
       />

--- a/frontend/src/store/user-store.ts
+++ b/frontend/src/store/user-store.ts
@@ -12,7 +12,17 @@ import {
   type TokenPair,
   type UserInfo,
 } from '@/api/auth-api';
-import { getRequestErrorMessage, HttpError } from '@/utils/request';
+import {
+  getRequestErrorMessage,
+  HttpError,
+  isServiceUnavailableError,
+} from '@/utils/request';
+
+/** 认证服务暂时不可用时的统一提示文案。
+ *
+ * 导出常量便于 MainContent 等组件精确匹配该场景，避免用模糊的字符串
+ * 包含判断区分错误类型。 */
+export const AUTH_SERVICE_UNAVAILABLE_MESSAGE = '认证服务暂时不可用，请稍后重试';
 
 interface AuthState {
   /** 是否已登录 */
@@ -206,14 +216,16 @@ export const useUserStore = create<AuthState>((set) => ({
         });
         return;
       }
+      // 服务不可用（连接被拒绝/超时/5xx 网关错误）：保留登录态，提示重试，
+      // 避免后端短暂不可用时把已登录用户踢回登录页。
+      const serviceDown = isServiceUnavailableError(error);
       set({
         restoring: false,
         isAuthenticated: true,
         profileLoading: false,
-        profileError: getRequestErrorMessage(
-          error,
-          '用户信息加载失败，请稍后重试',
-        ),
+        profileError: serviceDown
+          ? AUTH_SERVICE_UNAVAILABLE_MESSAGE
+          : getRequestErrorMessage(error, '用户信息加载失败，请稍后重试'),
       });
     }
   },
@@ -276,12 +288,12 @@ export const useUserStore = create<AuthState>((set) => ({
         });
         return;
       }
+      const serviceDown = isServiceUnavailableError(error);
       set({
         profileLoading: false,
-        profileError: getRequestErrorMessage(
-          error,
-          '用户信息加载失败，请稍后重试',
-        ),
+        profileError: serviceDown
+          ? AUTH_SERVICE_UNAVAILABLE_MESSAGE
+          : getRequestErrorMessage(error, '用户信息加载失败，请稍后重试'),
       });
     }
   },

--- a/frontend/src/store/user-store.ts
+++ b/frontend/src/store/user-store.ts
@@ -13,16 +13,20 @@ import {
   type UserInfo,
 } from '@/api/auth-api';
 import {
+  appendTraceId,
   getRequestErrorMessage,
   HttpError,
   isServiceUnavailableError,
 } from '@/utils/request';
 
-/** 认证服务暂时不可用时的统一提示文案。
+/** 认证服务暂时不可用时的统一基础文案（不含 traceId）。
  *
- * 导出常量便于 MainContent 等组件精确匹配该场景，避免用模糊的字符串
- * 包含判断区分错误类型。 */
+ * 实际展示时通过 appendTraceId 追加 traceId。组件判别场景请使用
+ * profileErrorKind 而非字符串匹配，避免文案调整或追加 traceId 后分支失效。 */
 export const AUTH_SERVICE_UNAVAILABLE_MESSAGE = '认证服务暂时不可用，请稍后重试';
+
+/** 用户资料加载失败的错误种类，供 UI 按结构化标记分支展示。 */
+export type ProfileErrorKind = 'service-unavailable' | 'business';
 
 interface AuthState {
   /** 是否已登录 */
@@ -37,6 +41,8 @@ interface AuthState {
   profileLoading: boolean;
   /** 用户资料异步加载失败时的可恢复错误。 */
   profileError: string | null;
+  /** 用户资料加载失败的错误种类，供 UI 按结构化标记分支展示（替代字符串匹配）。 */
+  profileErrorKind: ProfileErrorKind | null;
   /** 登录态恢复中（页面刷新时 restoreAuth 执行期间为 true，完成后置 false） */
   restoring: boolean;
   /** 当前用户可见的菜单树；空数组表示尚未加载或未授权。 */
@@ -106,6 +112,7 @@ export const useUserStore = create<AuthState>((set) => ({
   loading: false,
   profileLoading: false,
   profileError: null,
+  profileErrorKind: null,
   // 初始 true：AppInitializer 的 restoreAuth 完成前，RequireAuth 显示加载动画而非立即跳转登录页
   restoring: true,
   menus: [],
@@ -121,6 +128,7 @@ export const useUserStore = create<AuthState>((set) => ({
         loading: false,
         restoring: false,
         profileError: null,
+        profileErrorKind: null,
       });
       void useUserStore.getState().hydrateCurrentUser();
       return tokenPair;
@@ -147,6 +155,7 @@ export const useUserStore = create<AuthState>((set) => ({
         loading: false,
         profileLoading: false,
         profileError: null,
+        profileErrorKind: null,
       });
     } catch (error) {
       set({ loading: false });
@@ -169,6 +178,7 @@ export const useUserStore = create<AuthState>((set) => ({
         menus: [],
         profileLoading: false,
         profileError: null,
+        profileErrorKind: null,
       });
     }
   },
@@ -190,6 +200,7 @@ export const useUserStore = create<AuthState>((set) => ({
       restoring: false,
       profileLoading: true,
       profileError: null,
+      profileErrorKind: null,
     });
     try {
       const info = await fetchCurrentUserOnce();
@@ -201,6 +212,7 @@ export const useUserStore = create<AuthState>((set) => ({
         restoring: false,
         profileLoading: false,
         profileError: null,
+        profileErrorKind: null,
       });
     } catch (error) {
       if (isAuthenticationFailure(error)) {
@@ -213,18 +225,21 @@ export const useUserStore = create<AuthState>((set) => ({
           menus: [],
           profileLoading: false,
           profileError: null,
+          profileErrorKind: null,
         });
         return;
       }
       // 服务不可用（连接被拒绝/超时/5xx 网关错误）：保留登录态，提示重试，
       // 避免后端短暂不可用时把已登录用户踢回登录页。
       const serviceDown = isServiceUnavailableError(error);
+      const traceId = error instanceof HttpError ? error.traceId : undefined;
       set({
         restoring: false,
         isAuthenticated: true,
         profileLoading: false,
+        profileErrorKind: serviceDown ? 'service-unavailable' : 'business',
         profileError: serviceDown
-          ? AUTH_SERVICE_UNAVAILABLE_MESSAGE
+          ? appendTraceId(AUTH_SERVICE_UNAVAILABLE_MESSAGE, traceId)
           : getRequestErrorMessage(error, '用户信息加载失败，请稍后重试'),
       });
     }
@@ -239,12 +254,13 @@ export const useUserStore = create<AuthState>((set) => ({
       menus: [],
       profileLoading: false,
       profileError: null,
+      profileErrorKind: null,
     });
   },
 
   reloadMenus: async () => {
     // 菜单/权限变更后，重新拉取 /auth/me 刷新本地缓存的菜单树与权限码
-    set({ profileLoading: true, profileError: null });
+    set({ profileLoading: true, profileError: null, profileErrorKind: null });
     try {
       const info = await fetchCurrentUserOnce();
       set({
@@ -253,6 +269,7 @@ export const useUserStore = create<AuthState>((set) => ({
         menus: info.menus ?? [],
         profileLoading: false,
         profileError: null,
+        profileErrorKind: null,
       });
     } catch (error) {
       set({ profileLoading: false });
@@ -265,7 +282,7 @@ export const useUserStore = create<AuthState>((set) => ({
     if (currentState.profileLoading || currentState.userInfo) {
       return;
     }
-    set({ profileLoading: true, profileError: null });
+    set({ profileLoading: true, profileError: null, profileErrorKind: null });
     try {
       const info = await fetchCurrentUserOnce();
       set({
@@ -274,6 +291,7 @@ export const useUserStore = create<AuthState>((set) => ({
         menus: info.menus ?? [],
         profileLoading: false,
         profileError: null,
+        profileErrorKind: null,
       });
     } catch (error) {
       if (isAuthenticationFailure(error)) {
@@ -285,14 +303,17 @@ export const useUserStore = create<AuthState>((set) => ({
           menus: [],
           profileLoading: false,
           profileError: null,
+          profileErrorKind: null,
         });
         return;
       }
       const serviceDown = isServiceUnavailableError(error);
+      const traceId = error instanceof HttpError ? error.traceId : undefined;
       set({
         profileLoading: false,
+        profileErrorKind: serviceDown ? 'service-unavailable' : 'business',
         profileError: serviceDown
-          ? AUTH_SERVICE_UNAVAILABLE_MESSAGE
+          ? appendTraceId(AUTH_SERVICE_UNAVAILABLE_MESSAGE, traceId)
           : getRequestErrorMessage(error, '用户信息加载失败，请稍后重试'),
       });
     }

--- a/frontend/src/utils/request.ts
+++ b/frontend/src/utils/request.ts
@@ -6,7 +6,7 @@ import axios, {
 } from 'axios';
 import { createTraceHeaders, TRACE_ID_HEADER } from './trace-context';
 
-/** HTTP 错误：保留 status/data/config/code/traceId 等结构化字段，便于调用方按状态码分支处理 */
+/** HTTP 错误：保留 status/data/config/code/traceId/networkError 等结构化字段，便于调用方按状态码分支处理 */
 export class HttpError extends Error {
   readonly status?: number;
   readonly code?: string;
@@ -14,6 +14,13 @@ export class HttpError extends Error {
   readonly config?: unknown;
   /** 本次请求的 traceId，便于联调 debug 与日志查询页定位 */
   readonly traceId?: string;
+  /** 是否为网络层失败（无 HTTP 响应：连接被拒绝/DNS 失败/超时无响应）。
+   *
+   * 用于区分“服务不可达（可重试）”与“业务失败（HTTP 200 + success:false，
+   * status 同样为 undefined）”——后者不应被判为服务不可用，否则用户会卡在
+   * 伪登录态死循环（如“用户已被禁用”永远重试不成功）。
+   */
+  readonly networkError?: boolean;
 
   constructor(
     message: string,
@@ -23,6 +30,7 @@ export class HttpError extends Error {
       data?: unknown;
       config?: unknown;
       traceId?: string;
+      networkError?: boolean;
     } = {},
   ) {
     super(message);
@@ -32,6 +40,7 @@ export class HttpError extends Error {
     this.data = opts.data;
     this.config = opts.config;
     this.traceId = opts.traceId;
+    this.networkError = opts.networkError;
   }
 }
 
@@ -53,10 +62,17 @@ function readHeader(headers: unknown, name: string): string | undefined {
     }
     return undefined;
   }
-  // 普通对象：按小写 key 读取
-  const lower = (headers as Record<string, unknown>)[name.toLowerCase()];
-  if (typeof lower === 'string' && lower.trim()) {
-    return lower.trim();
+  // 普通对象：遍历 key 做大小写不敏感匹配，兼容未归一化的 header 字典
+  const target = name.toLowerCase();
+  const record = headers as Record<string, unknown>;
+  for (const key of Object.keys(record)) {
+    if (key.toLowerCase() === target) {
+      const value = record[key];
+      if (typeof value === 'string' && value.trim()) {
+        return value.trim();
+      }
+      return undefined;
+    }
   }
   return undefined;
 }
@@ -185,7 +201,7 @@ export abstract class BaseRequest {
       (error) => Promise.reject(error),
     );
 
-    // 响应拦截：normalize HTTP 错误为 HttpError（保留 status/code/data/config/traceId），
+    // 响应拦截：normalize HTTP 错误为 HttpError（保留 status/code/data/config/traceId/networkError），
     // 不展示错误（不耦合 UI 库），调用方在 catch 中自行展示
     this.instance.interceptors.response.use(
       (response: AxiosResponse) => response,
@@ -195,9 +211,13 @@ export abstract class BaseRequest {
           return recoveredResponse;
         }
         const { message, status, code, data, config } = this.buildHttpError(error);
+        // 网络层失败：axios 错误无 response 字段（连接被拒绝/DNS 失败/超时无响应）。
+        // 业务失败（HTTP 200 + success:false）在 unwrapResponse 中抛出，不走拦截器，
+        // 其 networkError 保持 undefined，从而不会被 isServiceUnavailableError 误判。
+        const networkError = !hasField(error, 'response');
         const traceId = extractTraceId(error);
         return Promise.reject(
-          new HttpError(message, { status, code, data, config, traceId }),
+          new HttpError(message, { status, code, data, config, traceId, networkError }),
         );
       },
     );
@@ -313,9 +333,14 @@ export abstract class BaseRequest {
 /** 判断是否为服务不可用类错误。
  *
  * 覆盖两种场景：
- *   - 网络层失败（连接被拒绝/DNS 失败/超时无响应）：HttpError.status 为
- *     undefined，axios 错误未携带 HTTP 响应；
+ *   - 网络层失败（连接被拒绝/DNS 失败/超时无响应）：HttpError.networkError
+ *     为 true（由响应拦截器在 axios 错误无 response 时设置）；
  *   - 网关类 5xx（502/503/504）：上游服务或网关自身不可用。
+ *
+ * 不再用 `status === undefined` 判定网络层失败——业务失败（HTTP 200 +
+ * success:false）在 unwrapResponse 中抛出的 HttpError 同样 status 为
+ * undefined，但 networkError 为 undefined，从而不会误命中本函数，避免
+ * “用户已被禁用”等业务错误陷入伪登录态死循环。
  *
  * 调用方据此区分“服务暂时不可用（可重试）”与“业务返回的错误（如 403）”，
  * 避免在后端短暂不可用时把已登录用户重定向回登录页。
@@ -325,7 +350,7 @@ export function isServiceUnavailableError(error: unknown): boolean {
     return false;
   }
   return (
-    error.status === undefined
+    error.networkError === true
     || error.status === 502
     || error.status === 503
     || error.status === 504
@@ -353,8 +378,12 @@ export function getRequestErrorMessage(error: unknown, fallback = '请求失败'
   return error instanceof Error ? error.message : fallback;
 }
 
-/** 在错误文案末尾追加 traceId；无 traceId 时原样返回。 */
-function appendTraceId(message: string, traceId: string | undefined): string {
+/** 在错误文案末尾追加 traceId；无 traceId 时原样返回。
+ *
+ * 导出供 store 在“服务不可用”等固定基础文案场景也保留 traceId，确保最需要
+ * 排查的网络层失败场景（响应头缺失，traceId 来自前端请求头）也能反馈线索。
+ */
+export function appendTraceId(message: string, traceId: string | undefined): string {
   if (!traceId) {
     return message;
   }

--- a/frontend/src/utils/request.ts
+++ b/frontend/src/utils/request.ts
@@ -6,16 +6,24 @@ import axios, {
 } from 'axios';
 import { createTraceHeaders, TRACE_ID_HEADER } from './trace-context';
 
-/** HTTP 错误：保留 status/data/config/code 等结构化字段，便于调用方按状态码分支处理 */
+/** HTTP 错误：保留 status/data/config/code/traceId 等结构化字段，便于调用方按状态码分支处理 */
 export class HttpError extends Error {
   readonly status?: number;
   readonly code?: string;
   readonly data?: unknown;
   readonly config?: unknown;
+  /** 本次请求的 traceId，便于联调 debug 与日志查询页定位 */
+  readonly traceId?: string;
 
   constructor(
     message: string,
-    opts: { status?: number; code?: string; data?: unknown; config?: unknown } = {},
+    opts: {
+      status?: number;
+      code?: string;
+      data?: unknown;
+      config?: unknown;
+      traceId?: string;
+    } = {},
   ) {
     super(message);
     this.name = 'HttpError';
@@ -23,12 +31,58 @@ export class HttpError extends Error {
     this.code = opts.code;
     this.data = opts.data;
     this.config = opts.config;
+    this.traceId = opts.traceId;
   }
 }
 
 /** 响应体形状探测：是否包含指定字段 */
 function hasField<T extends string>(body: unknown, field: T): body is Record<T, unknown> {
   return body != null && typeof body === 'object' && field in body;
+}
+
+/** 从 AxiosHeaders（支持 .get()）或普通对象中读取指定头，大小写不敏感。 */
+function readHeader(headers: unknown, name: string): string | undefined {
+  if (headers == null || typeof headers !== 'object') {
+    return undefined;
+  }
+  // AxiosHeaders 实例：.get() 内部已做大小写归一
+  if ('get' in headers && typeof (headers as { get: unknown }).get === 'function') {
+    const value = (headers as { get: (n: string) => unknown }).get(name);
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim();
+    }
+    return undefined;
+  }
+  // 普通对象：按小写 key 读取
+  const lower = (headers as Record<string, unknown>)[name.toLowerCase()];
+  if (typeof lower === 'string' && lower.trim()) {
+    return lower.trim();
+  }
+  return undefined;
+}
+
+/** 从 axios 错误中提取 traceId。
+ *
+ * 优先读响应头（后端 TraceMiddleware 回写的 X-Trace-Id）；
+ * 网络层失败无响应时回退读请求头（前端 createTraceHeaders 生成的值），
+ * 保证即使后端不可达也能拿到 traceId 供日志排查。
+ */
+function extractTraceId(error: unknown): string | undefined {
+  if (!(error instanceof Error)) {
+    return undefined;
+  }
+  if (hasField(error, 'response')) {
+    const response = error.response as { headers?: unknown } | undefined;
+    const responseTraceId = readHeader(response?.headers, TRACE_ID_HEADER);
+    if (responseTraceId) {
+      return responseTraceId;
+    }
+  }
+  if (hasField(error, 'config')) {
+    const config = error.config as { headers?: unknown } | undefined;
+    return readHeader(config?.headers, TRACE_ID_HEADER);
+  }
+  return undefined;
 }
 
 /** 从 unknown 响应体中安全读取 string 类型 message 字段 */
@@ -131,7 +185,7 @@ export abstract class BaseRequest {
       (error) => Promise.reject(error),
     );
 
-    // 响应拦截：normalize HTTP 错误为 HttpError（保留 status/code/data/config），
+    // 响应拦截：normalize HTTP 错误为 HttpError（保留 status/code/data/config/traceId），
     // 不展示错误（不耦合 UI 库），调用方在 catch 中自行展示
     this.instance.interceptors.response.use(
       (response: AxiosResponse) => response,
@@ -141,7 +195,10 @@ export abstract class BaseRequest {
           return recoveredResponse;
         }
         const { message, status, code, data, config } = this.buildHttpError(error);
-        return Promise.reject(new HttpError(message, { status, code, data, config }));
+        const traceId = extractTraceId(error);
+        return Promise.reject(
+          new HttpError(message, { status, code, data, config, traceId }),
+        );
       },
     );
   }
@@ -224,14 +281,15 @@ export abstract class BaseRequest {
 
   /**
    * 业务响应解包：校验 isSuccess，提取 data。
-   * 业务失败时抛 HttpError（携带 code/message/data），调用方可在 catch 中
-   * 通过 error.code 做差异化处理（如 RATE_LIMIT_EXCEEDED 显示倒计时）。
+   * 业务失败时抛 HttpError（携带 code/message/data/traceId），调用方可在
+   * catch 中通过 error.code 做差异化处理（如 RATE_LIMIT_EXCEEDED 显示倒计时）。
    */
-  protected unwrapResponse<T>(body: unknown): T {
+  protected unwrapResponse<T>(body: unknown, responseHeaders?: unknown): T {
     if (!this.isSuccess(body)) {
       throw new HttpError(this.getErrorMessage(body), {
         code: this.getErrorCode(body),
         data: body,
+        traceId: readHeader(responseHeaders, TRACE_ID_HEADER),
       });
     }
     return this.extractData(body) as T;
@@ -240,15 +298,15 @@ export abstract class BaseRequest {
   // ── 类型化包装方法 ──────────────────────────────
 
   get<T>(url: string, config?: AxiosRequestConfig): Promise<T> {
-    return this.instance.get(url, config).then((res) => this.unwrapResponse<T>(res.data));
+    return this.instance.get(url, config).then((res) => this.unwrapResponse<T>(res.data, res.headers));
   }
 
   post<T>(url: string, data?: unknown, config?: AxiosRequestConfig): Promise<T> {
-    return this.instance.post(url, data, config).then((res) => this.unwrapResponse<T>(res.data));
+    return this.instance.post(url, data, config).then((res) => this.unwrapResponse<T>(res.data, res.headers));
   }
 
   delete<T>(url: string, config?: AxiosRequestConfig): Promise<T> {
-    return this.instance.delete(url, config).then((res) => this.unwrapResponse<T>(res.data));
+    return this.instance.delete(url, config).then((res) => this.unwrapResponse<T>(res.data, res.headers));
   }
 }
 
@@ -279,17 +337,28 @@ export function isServiceUnavailableError(error: unknown): boolean {
  * 如果是 HttpError 且携带业务码，返回 `[CODE] message` 格式；
  * 否则返回纯 message。这样前端 message.error 能直接显示业务码+原因，
  * 便于用户定位问题（如 [PERMISSION_DENIED] 无权限访问）。
+ *
+ * 当 HttpError 携带 traceId 时，统一在末尾追加 `（traceId: xxx）`，
+ * 方便用户把提示反馈给开发人员后，在日志查询页按 traceId 精确定位链路。
  */
 export function getRequestErrorMessage(error: unknown, fallback = '请求失败'): string {
   if (error instanceof HttpError) {
     const nestedCode = readNestedErrorCode(error.data);
     const errorCode = error.code ?? nestedCode;
-    if (errorCode) {
-      return `[${errorCode}] ${error.message}`;
-    }
-    return error.message;
+    const baseMessage = errorCode
+      ? `[${errorCode}] ${error.message}`
+      : error.message;
+    return appendTraceId(baseMessage, error.traceId);
   }
   return error instanceof Error ? error.message : fallback;
+}
+
+/** 在错误文案末尾追加 traceId；无 traceId 时原样返回。 */
+function appendTraceId(message: string, traceId: string | undefined): string {
+  if (!traceId) {
+    return message;
+  }
+  return `${message}（traceId: ${traceId}）`;
 }
 
 /** 从统一 429 响应的 data.detail 中读取服务端限流剩余秒数。 */

--- a/frontend/src/utils/request.ts
+++ b/frontend/src/utils/request.ts
@@ -252,6 +252,28 @@ export abstract class BaseRequest {
   }
 }
 
+/** 判断是否为服务不可用类错误。
+ *
+ * 覆盖两种场景：
+ *   - 网络层失败（连接被拒绝/DNS 失败/超时无响应）：HttpError.status 为
+ *     undefined，axios 错误未携带 HTTP 响应；
+ *   - 网关类 5xx（502/503/504）：上游服务或网关自身不可用。
+ *
+ * 调用方据此区分“服务暂时不可用（可重试）”与“业务返回的错误（如 403）”，
+ * 避免在后端短暂不可用时把已登录用户重定向回登录页。
+ */
+export function isServiceUnavailableError(error: unknown): boolean {
+  if (!(error instanceof HttpError)) {
+    return false;
+  }
+  return (
+    error.status === undefined
+    || error.status === 502
+    || error.status === 503
+    || error.status === 504
+  );
+}
+
 /** 通用错误信息提取。
  *
  * 如果是 HttpError 且携带业务码，返回 `[CODE] message` 格式；


### PR DESCRIPTION
## 背景

- auth 服务未运行时（ECONNREFUSED 127.0.0.1:8020），前端 /auth/me 拿到的网络错误提示文案模糊，用户无法区分"服务不可用"与"业务错误"，且容易被误判为登录态失效。
- 线上联调定位问题时缺少统一的 traceId 入口：前端请求拦截器已发送 X-Trace-Id，后端 TraceMiddleware 也已回写响应头，但前端未提取、未展示，错误反馈无法对接日志查询页。

## 改动

### 1. 认证服务不可用时保留登录态（commit 62dd5da）

- **utils/request.ts**：新增 isServiceUnavailableError，识别网络层失败（status === undefined，即连接被拒绝/超时无响应）与 502/503/504 网关错误。
- **store/user-store.ts**：restoreAuth 与 hydrateCurrentUser 在服务不可用时**保留登录态**（isAuthenticated: true）并设置统一文案 AUTH_SERVICE_UNAVAILABLE_MESSAGE，避免后端短暂不可用把已登录用户误踢回登录页；导出该常量供组件精确匹配。
- **Layout/components/MainContent.tsx**：按错误类型区分展示——服务不可用显示 warning 状态 + "认证服务暂时不可用" + "重试连接服务"按钮；其他业务错误显示 error 状态 + "重新加载"。

### 2. 错误提示统一携带 traceId（commit aa7488d）

- **HttpError 新增 traceId 字段**，调用方可通过 error.traceId 直接获取。
- **新增 extractTraceId**：优先从响应头 X-Trace-Id 读取（后端 TraceMiddleware 已回写），网络层失败无响应时回退读请求头前端生成的值，保证后端不可达也能拿到 traceId。
- **覆盖三个错误路径**：
  - HTTP 错误（4xx/5xx/网络层失败）：响应拦截器调用 extractTraceId
  - 业务失败（HTTP 200 但 success=false）：unwrapResponse 传入 res.headers 提取
  - 错误提示展示：getRequestErrorMessage 在末尾统一追加（traceId: xxx）
- getLoginErrorMessage / getRegisterErrorMessage 内部调用 getRequestErrorMessage，自动生效。

## 示例效果

- 登录失败：[INVALID_CREDENTIALS] 用户名或密码错误（traceId: 550e8400-...）
- 服务不可用：认证服务暂时不可用，请稍后重试（traceId: 550e8400-...）
- 服务不可达：无法连接到服务器（traceId: 550e8400-...）

用户把提示反馈给开发人员后，可直接在日志查询页用 traceId 精确定位全链路日志。

## 验证

- npm run lint 通过
- npm run build 通过
- scripts/start-all.py 全部服务启动成功，health 检查通过

## 关联

无关联 issue。基于 master 分支，2 个提交，3 个文件改动。
