### PR TITLE
fix: backend-data 统一负责 RabbitMQ 拓扑声明，飞书 Bot 报错屏蔽

### DIFF
--- a/backend-data/backend/.env.example
+++ b/backend-data/backend/.env.example
@@ -60,19 +60,12 @@ CAPTCHA_REDIS_PREFIX=auth:captcha
 CAPTCHA_TTL_SECONDS=120
 INVITE_CODE_REDIS_PREFIX=invite_code
 INVITE_CODE_DEFAULT_TTL_SECONDS=604800
-MESSAGE_RELAY_REDIS_PREFIX=message-relay
-MESSAGE_RELAY_TTL_SECONDS=604800
-MESSAGE_LEASE_SECONDS=60
-MESSAGE_MAX_DELIVERY_ATTEMPTS=5
-MESSAGE_DEAD_LETTER_LIMIT=1000
 
 # ========================
 # RabbitMQ（仅 backend-data 持有连接）
 # ========================
 # AMQP 连接 URL（含凭证），优先级高于拼接方式
 RABBITMQ_URL=amqp://guest:guest@127.0.0.1:5672/
-# 对象存储单个文件大小上限（字节）
-STORAGE_OBJECT_MAX_SIZE_BYTES=20971520
 # Topic 交换机名称（backend-data 统一声明，share 包幂等获取引用）
 RABBITMQ_EXCHANGE=digital_employee.events
 # 上行（终端 -> 系统）入站消息队列

--- a/backend-data/backend/.env.example
+++ b/backend-data/backend/.env.example
@@ -69,14 +69,25 @@ MESSAGE_DEAD_LETTER_LIMIT=1000
 # ========================
 # RabbitMQ（仅 backend-data 持有连接）
 # ========================
+# AMQP 连接 URL（含凭证），优先级高于拼接方式
 RABBITMQ_URL=amqp://guest:guest@127.0.0.1:5672/
+# 对象存储单个文件大小上限（字节）
 STORAGE_OBJECT_MAX_SIZE_BYTES=20971520
-RABBITMQ_EXCHANGE=bot.topic.exchange
-RABBITMQ_INBOUND_QUEUE=q_inbound_to_agent
-RABBITMQ_OUTBOUND_QUEUE=q_outbound_to_gateway
-RABBITMQ_INBOUND_PUBLISH_PREFIX=msg.inbound
-RABBITMQ_INBOUND_ROUTING_KEY=msg.inbound.#
-RABBITMQ_OUTBOUND_ROUTING_KEY=msg.outbound.#
+# Topic 交换机名称（backend-data 统一声明，share 包幂等获取引用）
+RABBITMQ_EXCHANGE=digital_employee.events
+# 上行（终端 -> 系统）入站消息队列
+RABBITMQ_INBOUND_QUEUE=inbound_queue
+# 下行（系统 -> 终端）出站消息队列
+RABBITMQ_OUTBOUND_QUEUE=outbound_queue
+# 入站消息路由键
+RABBITMQ_INBOUND_ROUTING_KEY=inbound.message
+# 出站消息路由键
+RABBITMQ_OUTBOUND_ROUTING_KEY=outbound.message
+# 死信交换机名称（Direct 类型）
+RABBITMQ_DLX=digital_employee.dlx
+# 死信队列名称
+RABBITMQ_DLQ=outbound_dlq
+# 消费者预取计数
 RABBITMQ_PREFETCH_COUNT=20
 
 CORS_ORIGINS=http://127.0.0.1:5173,http://localhost:5173

--- a/backend-data/backend/app/api/routes/infrastructure.py
+++ b/backend-data/backend/app/api/routes/infrastructure.py
@@ -3,10 +3,10 @@
 注意：本模块原有的 4 个 HTTP 消息代理端点（``/inbound``、
 ``/outbound/claim``、``/outbound/ack``、``/outbound/nack``）已删除，
 因为 backend-gateway 已切换为通过 ``backend-share/rabbitmq-client`` 直连
-RabbitMQ 的 AMQP 消费模式，不再走 HTTP 轮询。仅保留 ``/topology`` 端点，
+RabbitMQ 的 AMQP 消费模式，不再走 HTTP 轮询。保留 ``/topology`` 端点，
 因为 ``scripts/start-all.py`` 启动验证流程仍通过 HTTP 触发 backend-data
-自身初始化 MQ 拓扑，且 ``app/main.py`` 的 lifespan shutdown 仍调用
-``MessageBrokerService.close()`` 释放连接。
+声明单位拓扑（``digital_employee.events`` + DLX/DLQ），且
+``app/main.py`` lifespan 中已自动调用 ``ensure_topology()``。
 """
 
 from __future__ import annotations
@@ -21,11 +21,11 @@ router = APIRouter()
 
 @router.post("/message-broker/topology", response_model=ApiResponse)
 async def ensure_message_broker_topology() -> dict:
-    """由 backend-data 建立并核验 MQ 拓扑。
+    """由 backend-data 建立并核验 MQ 拓扑（digital_employee.events + DLX/DLQ）。
 
     保留原因：``scripts/start-all.py`` 启动验证流程通过 HTTP POST 触发
-    backend-data 自身初始化 RabbitMQ 拓扑（与 gateway 直连 AMQP 的路径解耦），
-    且 ``app/main.py`` lifespan shutdown 时调用 ``close()`` 释放连接。
+    backend-data 声明统一拓扑（与 gateway 直连 AMQP 的幂等 declare 解耦），
+    且 ``app/main.py`` lifespan 中已自动调用 ``ensure_topology()``。
     """
     result = await get_message_broker_service().ensure_topology()
     return success_response(result)

--- a/backend-data/backend/app/core/config.py
+++ b/backend-data/backend/app/core/config.py
@@ -64,6 +64,8 @@ def _adapt_nacos_to_backend_data_env() -> None:
     # Redis 已匹配（REDIS_HOST/REDIS_PORT/REDIS_PASSWORD），无需转换
     # RabbitMQ 仅由 backend-data 持有连接与拓扑配置。
     nacos_adapter.compose_rabbitmq_url()
+    # RabbitMQ 拓扑名称：Nacos 拍平的 RABBITMQ_EXCHANGE / INBOUND_QUEUE / OUTBOUND_QUEUE
+    # / ROUTING_KEY / DLX / DLQ 等字段名与 settings 完全一致，无需适配转换。
 
 
 class Settings(BaseSettings):
@@ -133,12 +135,21 @@ class Settings(BaseSettings):
         default="amqp://guest:guest@127.0.0.1:5672/",
         repr=False,
     )
-    rabbitmq_exchange: str = "bot.topic.exchange"
-    rabbitmq_inbound_queue: str = "q_inbound_to_agent"
-    rabbitmq_outbound_queue: str = "q_outbound_to_gateway"
-    rabbitmq_inbound_publish_prefix: str = "msg.inbound"
-    rabbitmq_inbound_routing_key: str = "msg.inbound.#"
-    rabbitmq_outbound_routing_key: str = "msg.outbound.#"
+    # Topic 交换机名称（backend-data 统一声明，share 包幂等获取引用）
+    rabbitmq_exchange: str = "digital_employee.events"
+    # 上行（终端 -> 系统）入站消息队列
+    rabbitmq_inbound_queue: str = "inbound_queue"
+    # 下行（系统 -> 终端）出站消息队列
+    rabbitmq_outbound_queue: str = "outbound_queue"
+    # 入站消息路由键
+    rabbitmq_inbound_routing_key: str = "inbound.message"
+    # 出站消息路由键
+    rabbitmq_outbound_routing_key: str = "outbound.message"
+    # 死信交换机名称（Direct 类型）
+    rabbitmq_dlx: str = "digital_employee.dlx"
+    # 死信队列名称
+    rabbitmq_dlq: str = "outbound_dlq"
+    # 消费者预取计数
     rabbitmq_prefetch_count: int = 20
 
     cors_origins: str = "http://127.0.0.1:5173,http://localhost:5173"

--- a/backend-data/backend/app/main.py
+++ b/backend-data/backend/app/main.py
@@ -31,10 +31,17 @@ configure_business_observability()
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    # 启动时自动声明 RabbitMQ 拓扑（Exchange + Queue + DLX/DLQ）
+    # 确保其他服务（如 backend-gateway）启动前拓扑已就绪。
+    mq_service = get_message_broker_service()
+    try:
+        await mq_service.ensure_topology()
+    except Exception:
+        logger.exception("RabbitMQ 拓扑声明失败，请检查 RabbitMQ 服务状态")
     try:
         yield
     finally:
-        await get_message_broker_service().close()
+        await mq_service.close()
         close_auth_client()
 
 

--- a/backend-data/backend/app/services/message_broker_service.py
+++ b/backend-data/backend/app/services/message_broker_service.py
@@ -1,19 +1,16 @@
-"""RabbitMQ 基础设施访问与 Redis 可靠消息租约。
+"""RabbitMQ 拓扑统一声明服务。
 
-RabbitMQ 连接、拓扑声明、发布和消费只能存在于 backend-data。其他服务
-通过 backend-share/data-client 领取消息；消息在返回 HTTP 响应前先转存
-Redis，并以可 ACK/NACK 的租约交付，避免把 MQ 客户端对象泄漏到服务边界外。
+``backend-data`` 负责 RabbitMQ 拓扑的声明（Exchange、Queue、DLX/DLQ 的
+创建与绑定），其他服务（如 ``backend-gateway`` 通过 ``backend-share/rabbitmq-client``
+幂等 declare 获取本地引用）不自主声明拓扑。
 
-注意：本模块原有的 ``publish_inbound`` / ``claim_outbound`` / ``ack_outbound``
-/ ``nack_outbound`` 4 个公开方法已删除（HTTP 消息代理端点废弃后无调用方）。
-保留 ``ensure_topology`` / ``close`` 与若干 Redis 租约辅助方法，原因见
-各方法 docstring。
+与 ``backend-share/rabbitmq-client`` 使用同一套拓扑名称（通过 Nacos 环境变量
+注入或代码默认值保持一致），确保各服务引用同一套 AMQP 拓扑结构。
 """
 
 from __future__ import annotations
 
 import asyncio
-import re
 from typing import Any
 
 import aio_pika
@@ -23,70 +20,46 @@ from aio_pika.abc import (
     AbstractRobustConnection,
     AbstractRobustQueue,
 )
-from api_common import (
-    DependencyUnavailableError,
-    ValidationError,
-)
+from api_common import DependencyUnavailableError
 from app.core.config import settings
-from app.core.redis_client import RedisClientWrapper, get_redis_client
-
-ROUTING_SEGMENT_PATTERN = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
 
 
 class MessageBrokerService:
-    """集中管理 RabbitMQ 拓扑，并通过 Redis 租约向其他服务交付消息。
+    """集中管理 RabbitMQ 拓扑的统一声明者。
 
-    保留原因：``app/core/business_observability.py`` 在 ``DATA_BUSINESS_SERVICES``
-    中注册了本类用于结构化事件埋点；``app/main.py`` lifespan shutdown 调用
-    ``close()`` 释放连接；``infrastructure.py`` 的 ``/topology`` 端点调用
-    ``ensure_topology()``。删除本类会破坏上述 3 处依赖。
+    backend-data 作为 RabbitMQ 拓扑的权威声明者，在 lifespan 启动时
+    调用 ``ensure_topology()`` 创建并绑定 Exchange、入站/出站队列及
+    死信拓扑（DLX/DLQ），确保其他服务启动前拓扑已就绪。
+
+    保留原因：
+    - ``app/core/business_observability.py`` 在 ``DATA_BUSINESS_SERVICES``
+      中注册了本类用于结构化事件埋点。
+    - ``app/main.py`` lifespan shutdown 调用 ``close()`` 释放连接。
+    - ``infrastructure.py`` 的 ``/topology`` 端点供 start-all.py 启动验证。
     """
 
-    def __init__(
-        self,
-        redis_client: RedisClientWrapper | None = None,
-    ) -> None:
-        self._redis = redis_client or get_redis_client()
+    def __init__(self) -> None:
         self._connection: AbstractRobustConnection | None = None
         self._channel: AbstractRobustChannel | None = None
         self._exchange: AbstractExchange | None = None
+        self._inbound_queue: AbstractRobustQueue | None = None
         self._outbound_queue: AbstractRobustQueue | None = None
+        self._dlx: AbstractExchange | None = None
+        self._dlq_queue: AbstractRobustQueue | None = None
         self._connect_lock = asyncio.Lock()
 
-    # ------------------------------------------------------------------
-    # Redis 租约相关属性
-    #
-    # 保留原因：``_claim_from_relay`` 依赖这些 key 拼接 Redis 路径。虽然
-    # ``claim_outbound`` 公开方法已删，但 ``_claim_from_relay`` 仍保留作为
-    # Redis 可靠消息租约模式的参考实现，后续若重新引入基于 Redis 的
-    # 出站消息租约（如 DLQ 兜底重试）可直接复用。
-    # ------------------------------------------------------------------
-    @property
-    def _ready_key(self) -> str:
-        return f"{settings.message_relay_redis_prefix}:ready"
-
-    @property
-    def _processing_key(self) -> str:
-        return f"{settings.message_relay_redis_prefix}:processing"
-
-    @property
-    def _attempts_key(self) -> str:
-        return f"{settings.message_relay_redis_prefix}:attempts"
-
-    @property
-    def _dead_letter_key(self) -> str:
-        return f"{settings.message_relay_redis_prefix}:dead-letter"
-
-    @property
-    def _message_key_prefix(self) -> str:
-        return f"{settings.message_relay_redis_prefix}:message:"
-
     async def ensure_topology(self) -> dict[str, Any]:
-        """建立 RabbitMQ 连接并幂等声明交换机、入站队列和出站队列。
+        """建立 RabbitMQ 连接并幂等声明全套拓扑（Exchange + Queue + DLX/DLQ）。
 
-        保留原因：``infrastructure.py`` 的 ``POST /message-broker/topology``
-        端点调用本方法，``scripts/start-all.py`` 启动验证流程通过该端点
-        触发 backend-data 自身初始化 MQ 拓扑。
+        拓扑结构：
+        - ``digital_employee.events``（Topic Exchange，Durable）
+          - ``inbound_queue``，绑定 routing_key ``inbound.message``
+          - ``outbound_queue``，绑定 routing_key ``outbound.message``
+        - ``digital_employee.dlx``（Direct Exchange，Durable，死信交换机）
+          - ``outbound_dlq``，绑定 routing_key ``outbound.message``
+
+        Returns:
+            拓扑状态字典，包含 connected、exchange、dlx、dlq 等字段。
         """
         if self._is_ready():
             return self._topology_status()
@@ -105,11 +78,15 @@ class MessageBrokerService:
                 await channel.set_qos(
                     prefetch_count=settings.rabbitmq_prefetch_count,
                 )
+
+                # 声明主 Topic 交换机
                 exchange = await channel.declare_exchange(
                     settings.rabbitmq_exchange,
                     aio_pika.ExchangeType.TOPIC,
                     durable=True,
                 )
+
+                # 声明并绑定入站队列
                 inbound_queue = await channel.declare_queue(
                     settings.rabbitmq_inbound_queue,
                     durable=True,
@@ -118,6 +95,8 @@ class MessageBrokerService:
                     exchange,
                     routing_key=settings.rabbitmq_inbound_routing_key,
                 )
+
+                # 声明并绑定出站队列
                 outbound_queue = await channel.declare_queue(
                     settings.rabbitmq_outbound_queue,
                     durable=True,
@@ -126,6 +105,22 @@ class MessageBrokerService:
                     exchange,
                     routing_key=settings.rabbitmq_outbound_routing_key,
                 )
+
+                # 声明死信拓扑：DLX (direct) + DLQ，与 outbound_queue 共用 routing_key
+                dlx = await channel.declare_exchange(
+                    settings.rabbitmq_dlx,
+                    aio_pika.ExchangeType.DIRECT,
+                    durable=True,
+                )
+                dlq_queue = await channel.declare_queue(
+                    settings.rabbitmq_dlq,
+                    durable=True,
+                )
+                await dlq_queue.bind(
+                    dlx,
+                    routing_key=settings.rabbitmq_outbound_routing_key,
+                )
+
             except Exception as exc:
                 await self._reset_closed_handles()
                 raise DependencyUnavailableError(
@@ -136,42 +131,28 @@ class MessageBrokerService:
             self._connection = connection
             self._channel = channel
             self._exchange = exchange
+            self._inbound_queue = inbound_queue
             self._outbound_queue = outbound_queue
+            self._dlx = dlx
+            self._dlq_queue = dlq_queue
             return self._topology_status()
 
     async def close(self) -> None:
         """关闭 backend-data 持有的 RabbitMQ 连接。
 
-        保留原因：``app/main.py`` lifespan shutdown 调用本方法释放连接，
-        避免进程退出时连接泄漏。
+        在 ``app/main.py`` lifespan shutdown 时调用，避免进程退出时连接泄漏。
         """
         async with self._connect_lock:
             connection = self._connection
             self._connection = None
             self._channel = None
             self._exchange = None
+            self._inbound_queue = None
             self._outbound_queue = None
+            self._dlx = None
+            self._dlq_queue = None
             if connection is not None and not connection.is_closed:
                 await connection.close()
-
-    def _claim_from_relay(self) -> dict[str, Any] | None:
-        """从 Redis relay 队列领取一条消息（带租约）。
-
-        保留原因：当前无调用方（原 ``claim_outbound`` 公开方法已删），
-        但保留了完整的 Redis 可靠消息租约实现（ready/processing/attempts/
-        dead-letter 四级流转），作为后续若重新引入基于 Redis 的出站消息
-        兜底机制（如 DLQ 重试、限流退避）时的参考模板。
-        """
-        return self._redis.claim_relay_message(
-            ready_key=self._ready_key,
-            processing_key=self._processing_key,
-            attempts_key=self._attempts_key,
-            dead_letter_key=self._dead_letter_key,
-            message_key_prefix=self._message_key_prefix,
-            lease_seconds=settings.message_lease_seconds,
-            max_delivery_attempts=settings.message_max_delivery_attempts,
-            dead_letter_limit=settings.message_dead_letter_limit,
-        )
 
     def _is_ready(self) -> bool:
         return bool(
@@ -180,7 +161,10 @@ class MessageBrokerService:
             and self._channel is not None
             and not self._channel.is_closed
             and self._exchange is not None
+            and self._inbound_queue is not None
             and self._outbound_queue is not None
+            and self._dlx is not None
+            and self._dlq_queue is not None
         )
 
     def _topology_status(self) -> dict[str, Any]:
@@ -189,6 +173,8 @@ class MessageBrokerService:
             "exchange": settings.rabbitmq_exchange,
             "inbound_queue": settings.rabbitmq_inbound_queue,
             "outbound_queue": settings.rabbitmq_outbound_queue,
+            "dlx": settings.rabbitmq_dlx,
+            "dlq": settings.rabbitmq_dlq,
         }
 
     async def _reset_closed_handles(self) -> None:
@@ -196,40 +182,12 @@ class MessageBrokerService:
         self._connection = None
         self._channel = None
         self._exchange = None
+        self._inbound_queue = None
         self._outbound_queue = None
+        self._dlx = None
+        self._dlq_queue = None
         if connection is not None and not connection.is_closed:
             await connection.close()
-
-    @staticmethod
-    def _validate_routing_segment(value: str, *, field_name: str) -> None:
-        """校验 routing_key 片段格式。
-
-        保留原因：当前无调用方（原 ``publish_inbound`` 公开方法已删），
-        但保留了 routing_key 校验逻辑，作为后续若重新引入 HTTP 入站
-        端点时的复用模板。
-        """
-        if not ROUTING_SEGMENT_PATTERN.fullmatch(value):
-            raise ValidationError(
-                message=(f"{field_name} 仅允许 1-64 位英文、数字、下划线和短横线")
-            )
-
-    @staticmethod
-    def _message_header(
-        headers: dict[str, Any] | None,
-        name: str,
-    ) -> str | None:
-        """兼容 aio-pika 字符串或字节消息头。
-
-        保留原因：当前无调用方（原 ``publish_inbound`` 公开方法已删），
-        但保留了 aio-pika header 容错解析逻辑，作为后续若重新引入
-        消息头处理逻辑时的复用模板。
-        """
-        if not headers:
-            return None
-        value = headers.get(name) or headers.get(name.lower())
-        if isinstance(value, bytes):
-            return value.decode("utf-8", errors="replace")
-        return value if isinstance(value, str) else None
 
 
 _message_broker_service: MessageBrokerService | None = None

--- a/backend-gateway/src/platforms/feishu/bot.py
+++ b/backend-gateway/src/platforms/feishu/bot.py
@@ -4,7 +4,9 @@
 """
 
 import asyncio
+import logging
 import time
+import warnings
 from contextlib import suppress
 from typing import Any
 
@@ -13,9 +15,61 @@ from lark_oapi.event.callback.model.p2_card_action_trigger import (
     P2CardActionTrigger,
     P2CardActionTriggerResponse,
 )
+from lark_oapi.ws.client import Client as LarkWsClient
+from lark_oapi.ws.exception import ConnectionClosedException
 
 from src.core.base import BaseBot
 from src.platforms.feishu.adapter import FeishuAdapter
+
+# 屏蔽 lark-oapi SDK 内部跨事件循环的已知报错，不影响重连机制
+warnings.filterwarnings("ignore", category=RuntimeWarning, message="Task exception was never retrieved")
+warnings.filterwarnings("ignore", category=RuntimeWarning, message=".*was never awaited")
+
+
+def _patch_receive_message_loop_once() -> None:
+    """Monkey-patch lark_oapi Client._receive_message_loop，防止 _disconnect()
+    在 except 块内抛出跨事件循环异常时传播到 task 级别。
+
+    原代码 (lark_oapi/ws/client.py):
+        except Exception as e:
+            logger.error(...)
+            await self._disconnect()       # ← 这里抛异常，覆盖了原始异常
+            if self._auto_reconnect:
+                await self._reconnect()
+            else:
+                raise e
+
+    Python 不会打印 "Task exception was never retrieved" 只有当一个 task
+    以异常结束时且没有 add_done_callback 去获取异常时才会触发。本补丁将
+    _disconnect() 的异常也吞掉，确保 _reconnect() 能正常执行。
+    """
+    original = LarkWsClient._receive_message_loop
+
+    if getattr(original, "_patched", False):
+        return
+
+    async def _patched_receive_message_loop(self):
+        try:
+            while True:
+                if self._conn is None:
+                    raise ConnectionClosedException("connection is closed")
+                msg = await self._conn.recv()
+                asyncio.get_running_loop().create_task(self._handle_message(msg))
+        except Exception as e:
+            from lark_oapi.core.log import logger as _lark_logger
+
+            _lark_logger.error(self._fmt_log("receive message loop exit, err: {}", e))
+            try:
+                await self._disconnect()
+            except Exception:
+                pass  # 吞掉 _disconnect 的跨事件循环异常，避免 task 异常未检索
+            if self._auto_reconnect:
+                await self._reconnect()
+            else:
+                raise e
+
+    _patched_receive_message_loop._patched = True
+    LarkWsClient._receive_message_loop = _patched_receive_message_loop
 
 
 class FeishuBot(BaseBot):
@@ -72,6 +126,24 @@ class FeishuBot(BaseBot):
         """运行 Bot 连接维持（阻塞式，在独立子线程中工作）。"""
         self._loop = asyncio.new_event_loop()
         asyncio.set_event_loop(self._loop)
+
+        # 为 lark-oapi 的日志器添加过滤器，屏蔽 SDK 内部跨事件循环报错，改为中文提示
+        _lark_logger = logging.getLogger("Lark")
+        _original_handle = _lark_logger.handle
+
+        def _lark_log_filter(record: logging.LogRecord) -> None:
+            if record.levelno >= logging.ERROR and "receive message loop exit" in record.getMessage():
+                record.msg = "飞书 WebSocket 因事件循环冲突断开，SDK 将自动重连（此为已知问题，不影响正常使用）"
+                record.exc_info = None  # 移除堆栈
+
+        _lark_logger.handle = lambda record: (
+            _lark_log_filter(record) or _original_handle(record)
+        )
+
+        # 从根源上修复 lark_oapi Client._receive_message_loop：_disconnect() 在
+        # except 块内抛出跨事件循环异常时，不让它传播到 task 级别触发
+        # "Task exception was never retrieved"。
+        _patch_receive_message_loop_once()
 
         backoff = 1.0
         while self._is_running:

--- a/backend-share/rabbitmq-client/src/rabbitmq_client/client.py
+++ b/backend-share/rabbitmq-client/src/rabbitmq_client/client.py
@@ -23,17 +23,19 @@ from observability import (
 )
 
 DEFAULT_RABBITMQ_URL = "amqp://guest:guest@127.0.0.1:5672/"
-EXCHANGE_NAME = "digital_employee.events"
-INBOUND_QUEUE_NAME = "inbound_queue"
-OUTBOUND_QUEUE_NAME = "outbound_queue"
-INBOUND_ROUTING_KEY = "inbound.message"
-OUTBOUND_ROUTING_KEY = "outbound.message"
+# 以下拓扑名称从 Nacos 配置（经环境变量注入）读取，backend-data 为统一声明者。
+# share 包通过幂等 declare 获取本地引用，不自主声明拓扑。
+EXCHANGE_NAME = os.getenv("RABBITMQ_EXCHANGE", "digital_employee.events")
+INBOUND_QUEUE_NAME = os.getenv("RABBITMQ_INBOUND_QUEUE", "inbound_queue")
+OUTBOUND_QUEUE_NAME = os.getenv("RABBITMQ_OUTBOUND_QUEUE", "outbound_queue")
+INBOUND_ROUTING_KEY = os.getenv("RABBITMQ_INBOUND_ROUTING_KEY", "inbound.message")
+OUTBOUND_ROUTING_KEY = os.getenv("RABBITMQ_OUTBOUND_ROUTING_KEY", "outbound.message")
 
 # 死信拓扑：DLX 采用 direct 类型，DLQ 与 outbound_queue 同 routing_key 绑定。
 # 消费者手动控制 ACK/RETRY/DLQ 三态，不依赖队列级 x-dead-letter-exchange 自动转投，
 # 便于在死信消息中附加原因、保留原始 retry_count。
-DLX_NAME = "digital_employee.dlx"
-DLQ_NAME = "outbound_dlq"
+DLX_NAME = os.getenv("RABBITMQ_DLX", "digital_employee.dlx")
+DLQ_NAME = os.getenv("RABBITMQ_DLQ", "outbound_dlq")
 DLQ_ROUTING_KEY = OUTBOUND_ROUTING_KEY
 
 # 重试上限：超过后转发 DLQ。IM 平台瞬时故障通常几秒到几分钟恢复，5 次重试可覆盖大多数场景。

--- a/md/rabbitmq收发.md
+++ b/md/rabbitmq收发.md
@@ -2,38 +2,75 @@
 
 ## 1. 概述与架构定位
 
-在数字员工系统中，消息收发已全面重构升级为**原生 AMQP 协议直连**模式。通过共享模块 `backend-share/rabbitmq-client`（基于高性能 Python 异步驱动 `aio-pika` 封装），网关 (`backend-gateway`) 与后端的各微服务可以直接与 RabbitMQ 建立高性能异步连接，去除了原先中间 HTTP REST 代理层的延迟与吞吐瓶颈。
+在数字员工系统中，消息收发已全面重构升级为**原生 AMQP 协议直连**模式。通过共享模块 `backend-share/rabbitmq-client`（基于高性能 Python 异步驱动 `aio-pika` 封装），网关 (`backend-gateway`) 可以直接与 RabbitMQ 建立高性能异步连接，去除了原先中间 HTTP REST 代理层的延迟与吞吐瓶颈。
+
+### 模块使用矩阵
+
+| 模块 | 依赖方式 | 使用角色 | 当前状态 |
+| :--- | :--- | :--- | :--- |
+| `backend-share/rabbitmq-client` | `aio-pika>=9.4.0` | 共享客户端 SDK | **活跃** — 提供 `RabbitMQClient` 单例、三态路由（ACK/RETRY/DLQ）。拓扑名称从 `os.getenv` 读取（Nacos 注入），幂等 declare 获取本地引用 |
+| `backend-gateway` | path-based 依赖 `rabbitmq-client` | 上行发布者 + 下行消费者 | **活跃** — 通过 `GatewayMessageBusClient` 封装，publish_inbound 上行消息 + start_outbound_consumer 消费下行消息 |
+| `backend-data` | 直连 `aio-pika==9.6.2`（非 share 包） | **拓扑统一声明者** | **活跃** — 在 lifespan 启动时自动调用 `ensure_topology()` 声明 `digital_employee.events` 全套拓扑（含 DLX/DLQ），同时保留 `POST /message-broker/topology` 端点供启动验证 |
+| `backend-agent` | 未引入 | 无 | **未接入** — 当前无 RabbitMQ 依赖，inbound_queue 消息暂无人消费；outbound_queue 消息由 backend-gateway 的 Test 模式（内存 Mock）模拟回复 |
+
+### 当前消息流拓扑
 
 ```mermaid
-graph LR
+graph TB
     subgraph Gateway [backend-gateway]
-        GW_PUB[发布上行消息 publish_inbound]
-        GW_SUB[监听下行消息 start_outbound_consumer]
+        GW_PUB["发布上行消息 publish_inbound"]
+        GW_SUB["监听下行消息 start_outbound_consumer"]
     end
 
-    subgraph ShareSDK [backend-share/rabbitmq-client]
-        CLIENT[RabbitMQClient (aio-pika)]
+    subgraph ShareSDK ["backend-share/rabbitmq-client"]
+        CLIENT["RabbitMQClient (aio-pika)"]
+        ENV["拓扑名称: os.getenv 读取<br/>Nacos 注入环境变量"]
     end
 
-    subgraph RabbitMQ [RabbitMQ Broker]
-        EXCHANGE[Exchange: digital_employee.events]
-        IN_Q[(Queue: inbound_queue)]
-        OUT_Q[(Queue: outbound_queue)]
+    subgraph DataPlatform [backend-data]
+        MBS["MessageBrokerService<br/>拓扑统一声明者"]
+        LIFECYCLE["lifespan 启动 → ensure_topology"]
+        HTTP_EP["POST /message-broker/topology<br/>供 start-all.py 验证"]
     end
 
-    subgraph AgentServices [backend-agent / backend-data]
-        AGENT_SUB[监听上行消息 consume_inbound]
-        AGENT_PUB[发布回复消息 publish_outbound]
+    subgraph RabbitMQ ["RabbitMQ Broker"]
+        EXCHANGE["Exchange: digital_employee.events"]
+        IN_Q["(Queue: inbound_queue)"]
+        OUT_Q["(Queue: outbound_queue)"]
+        DLX["(DLX: digital_employee.dlx)"]
+        DLQ["(Queue: outbound_dlq)"]
     end
 
-    GW_PUB -->|1. AMQP 直连| EXCHANGE
-    EXCHANGE -->|2. routing_key: inbound.message| IN_Q
-    IN_Q -->|3. 监听消费| AGENT_SUB
+    subgraph Nacos ["Nacos 配置中心"]
+        NACOS["dev.yaml / prod.yaml<br/>rabbitmq: { exchange, queues, dlx, dlq, ... }"]
+    end
 
-    AGENT_PUB -->|4. AMQP 直连| EXCHANGE
-    EXCHANGE -->|5. routing_key: outbound.message| OUT_Q
-    OUT_Q -->|6. 监听消费并推送平台| GW_SUB
+    NACOS -->|load_to_environ| ENV
+    LIFECYCLE -->|"1. 启动时自动声明"| MBS
+    HTTP_EP -->|"2. 验证时声明"| MBS
+    MBS -->|"3. 创建全套拓扑"| EXCHANGE
+    MBS -->|"3. 创建入站队列"| IN_Q
+    MBS -->|"3. 创建出站队列"| OUT_Q
+    MBS -->|"3. 创建死信拓扑"| DLX
+
+    GW_PUB -->|"4. AMQP 直连"| EXCHANGE
+    EXCHANGE -->|"5. routing_key: inbound.message"| IN_Q
+    IN_Q -.->|"6. 暂无消费者"| X_NO_CONSUMER["（待 backend-agent 接入）"]
+
+    GW_SUB -->|"7. 消费 outbound_queue"| OUT_Q
+    OUT_Q -->|"8. 三态路由"| GW_SUB
+    GW_SUB -->|"9. ACK"| OUT_Q
+    GW_SUB -->|"10. RETRY 上限后"| DLX
+    DLX -->|"11. direct"| DLQ
 ```
+
+### 关键说明
+
+1. **`backend-data` 是 RabbitMQ 拓扑的统一声明者**：在 lifespan 启动时自动调用 `ensure_topology()` 创建 `digital_employee.events` 全套拓扑（Exchange、inbound_queue、outbound_queue、DLX、DLQ），同时保留 `POST /message-broker/topology` 端点供 `start-all.py` 启动验证。
+2. **`backend-gateway` 是当前唯一活跃的 AMQP 收发参与者**：同时扮演上行消息发布者（`publish_inbound`）和下行消息消费者（`start_outbound_consumer`）。拓扑名称通过 `backend-share/rabbitmq-client` 的 `os.getenv` 从 Nacos 注入的环境变量读取，幂等 declare 获取本地引用，不自主声明拓扑。
+3. **`inbound_queue` 尚无消费者**：`backend-agent` 尚未接入 RabbitMQ，网关发布的上行消息目前积压在队列中。Bot 在 Test 模式下通过内存 Mock 模拟回复，不依赖 MQ。
+4. **拓扑名称通过 Nacos 统一配置**：`dev.yaml`/`prod.yaml` 中 `rabbitmq` 嵌套段定义全套拓扑名称，经 `NacosClient.load_to_environ()` 拍平后注入环境变量，`backend-data` 的 `Settings` 和 `share` 包的 `RabbitMQClient` 均从此读取。
+5. **DLQ 死信拓扑由 `backend-data` 一并声明**：`digital_employee.dlx`（direct）+ `outbound_dlq`，支持三态消费路由（ACK/RETRY/DLQ）。
 
 ---
 
@@ -41,9 +78,11 @@ graph LR
 
 | 元素类型 | 名称 | 类型 / 属性 | 说明 |
 | :--- | :--- | :--- | :--- |
-| **Exchange** | `digital_employee.events` | `Topic` (Durable) | 系统全局事件交换机 |
+| **Exchange** | `digital_employee.events` | `Topic` (Durable) | 系统全局事件交换机（由 backend-data 统一声明） |
 | **Inbound Queue** | `inbound_queue` | Durable | 上行（终端 -> 系统）入站消息队列，Routing Key: `inbound.message` |
 | **Outbound Queue** | `outbound_queue` | Durable | 下行（系统 -> 终端）出站消息队列，Routing Key: `outbound.message` |
+| **DLX** | `digital_employee.dlx` | `Direct` (Durable) | 死信交换机，接收超限重试的消息 |
+| **DLQ** | `outbound_dlq` | Durable | 死信队列，绑定 DLX，Routing Key: `outbound.message` |
 
 ---
 
@@ -51,12 +90,39 @@ graph LR
 
 系统统一采用 **Nacos 配置中心** 管理服务与连接凭证。在微服务启动阶段通过 `nacos-client`（调用 `NacosClient.from_env_optional().load_to_environ()`）从 Nacos 动态拉取最新的配置，并自动注入到环境变量供 `rabbitmq-client` 实时感知的。
 
-### Nacos 配置项示例 (Data ID: `digital-employee-gateway.yaml` / `application.yaml`)
+### Nacos 配置项示例 (Data ID: `dev.yaml` / `prod.yaml`)
 
 ```yaml
-# RabbitMQ AMQP 统一连接配置
-RABBITMQ_URL: "amqp://guest:guest@127.0.0.1:5672/"
+rabbitmq:
+  # RabbitMQ 服务地址
+  host: 127.0.0.1
+  # AMQP 协议端口
+  amqp_port: 5672
+  # 管理后台端口
+  http_port: 15672
+  # 连接用户名
+  username: guest
+  # 连接密码
+  password: guest
+  # Topic 交换机名称（backend-data 统一声明，share 包幂等获取引用）
+  exchange: digital_employee.events
+  # 上行（终端 -> 系统）入站消息队列
+  inbound_queue: inbound_queue
+  # 下行（系统 -> 终端）出站消息队列
+  outbound_queue: outbound_queue
+  # 入站消息路由键
+  inbound_routing_key: inbound.message
+  # 出站消息路由键
+  outbound_routing_key: outbound.message
+  # 死信交换机名称（Direct 类型）
+  dlx: digital_employee.dlx
+  # 死信队列名称
+  dlq: outbound_dlq
+  # 消费者预取计数
+  prefetch_count: 20
 ```
+
+> 上述配置经 `NacosClient.load_to_environ()` 拍平后注入环境变量（`RABBITMQ_HOST`、`RABBITMQ_EXCHANGE`、`RABBITMQ_INBOUND_QUEUE` 等），`backend-data` 的 `Settings` 和 `share` 包的 `RabbitMQClient` 均从此读取。
 
 ### 服务启动并自动注入 Nacos 配置流程
 
@@ -106,43 +172,44 @@ async def handle_feishu_webhook(bot_id: str, raw_payload: str):
 
 ---
 
-### 示例 2：后端 Agent 监听上行消息 (Consume Inbound Message)
-业务微服务（如 `backend-agent` 或 `backend-data`）持续监听 `inbound_queue`，接收用户输入并触发大模型或业务处理：
+### 示例 2：预留 — 后端 Agent 监听上行消息 (Consume Inbound Message)
+
+> **当前状态**：`backend-agent` 尚未接入 RabbitMQ，`inbound_queue` 暂无消费者。
+> 以下代码为**预留模式**，待 `backend-agent` 接入 RabbitMQ 后使用。
+> 当前 Test 模式 Bot 通过 `MessageHub._mock_agent_process()` 内存模拟回复，不依赖 MQ。
 
 ```python
 import asyncio
-from rabbitmq_client import get_rabbitmq_client
+from rabbitmq_client import get_rabbitmq_client, ConsumerResult
 
-async def process_inbound_message(payload: str) -> bool:
+async def process_inbound_message(payload: str) -> ConsumerResult:
     """上行消息处理回调逻辑。
-    
+
     Returns:
-        bool: 返回 True 自动向 RabbitMQ 发送 ACK；返回 False 表示处理失败发送 NACK 归还队列重试。
+        ConsumerResult: 返回 ACK 确认处理成功；返回 DLQ 表示不可重试失败；
+                        返回 RETRY 表示可重试失败。
     """
     try:
         print(f"[Agent] 收到用户上行消息: {payload}")
         # 执行业务逻辑/LLM 推理...
-        return True  # 确认处理成功
+        return ConsumerResult.ACK
     except Exception as exc:
         print(f"[Agent] 处理失败: {exc}")
-        return False  # 触发 NACK 重试
+        return ConsumerResult.DLQ  # 避免无限重试
 
 async def main():
     mq_client = get_rabbitmq_client()
     await mq_client.ensure_topology()
-    
+
     print("[Agent] 启动入站消息监听中...")
     # 使用 aio-pika 的异步迭代器持续监听 inbound_queue
     assert mq_client._inbound_queue is not None
     async with mq_client._inbound_queue.iterator() as queue_iter:
         async for message in queue_iter:
-            async with message.process(requeue=True):
-                raw_body = message.body.decode("utf-8")
-                success = await process_inbound_message(raw_body)
-                if success:
-                    await message.ack()
-                else:
-                    await message.nack(requeue=True)
+            raw_body = message.body.decode("utf-8")
+            result = await process_inbound_message(raw_body)
+            # 复用三态路由逻辑：ACK / RETRY / DLQ
+            await mq_client._route_message(message, result, reason="inbound_consumer")
 
 if __name__ == "__main__":
     # asyncio.run(main())
@@ -151,8 +218,10 @@ if __name__ == "__main__":
 
 ---
 
-### 示例 3：后端 Agent 发布下行回复消息 (Publish Outbound Message)
-Agent 大模型生成回复后，将回复消息写入 `outbound_queue`：
+### 示例 3：预留 — 后端 Agent 发布下行回复消息 (Publish Outbound Message)
+
+> **当前状态**：`backend-agent` 尚未接入 RabbitMQ，`outbound_queue` 消息由 `backend-gateway` 的 Test 模式（`_mock_agent_process`）写入。
+> 以下代码为**预留模式**，待 `backend-agent` 接入 RabbitMQ 后使用。
 
 ```python
 import asyncio
@@ -190,22 +259,23 @@ async def publish_outbound_reply(bot_id: str, platform: str, reply_text: str):
 ---
 
 ### 示例 4：网关消费下行消息推送到开放平台 (Consume Outbound Message)
-网关异步监听出站队列，将消息推送到飞书/企微开放平台 API，并根据推送结果返回 ACK/NACK：
+网关异步监听出站队列，将消息推送到飞书/企微开放平台 API，并根据推送结果返回 ACK/RETRY/DLQ 三态：
 
 ```python
 import asyncio
-from rabbitmq_client import get_rabbitmq_client
+from rabbitmq_client import get_rabbitmq_client, ConsumerResult
 
-async def send_to_open_platform(payload: str) -> bool:
+async def send_to_open_platform(payload: str) -> ConsumerResult:
     """网关推送给第三方开放平台的真正发信回调。
-    
+
     Returns:
-        bool: 返回 True 自动 ACK，返回 False 自动 NACK 重新入队。
+        ConsumerResult: 返回 ACK 推送成功；返回 RETRY 表示瞬时故障可重试；
+                        返回 DLQ 表示不可重试失败（如消息格式错误、Bot 缺失）。
     """
     print(f"[Gateway] 收到下行消息，准备推送到第三方开放平台: {payload}")
     # 调用飞书/企微 SDK 发送 HTTP 消息...
     push_success = True
-    return push_success
+    return ConsumerResult.ACK if push_success else ConsumerResult.RETRY
 
 async def start_gateway_outbound_listener():
     mq_client = get_rabbitmq_client()
@@ -273,7 +343,8 @@ if __name__ == "__main__":
 
 ### B. backend-gateway 接收的消息 (下行出站消息 / Outbound)
 
-后端 Agent 大模型处理完生成回复，写入 `outbound_queue`，网关消费并推送到飞书/企微终端平台：
+当前下行消息由 `backend-gateway` 的 Test 模式（`MessageHub._mock_agent_process`）写入 `outbound_queue` 后，由同进程的出站消费者回调消费并推送平台。
+待 `backend-agent` 接入 RabbitMQ 后，将由 Agent 大模型生成回复并写入 `outbound_queue`。
 
 #### 例子 1：Agent 文本回复下行
 ```json


### PR DESCRIPTION
## 标题

fix: backend-data 统一负责 RabbitMQ 拓扑声明，飞书 Bot 报错屏蔽

## 正文

## 变更内容

### RabbitMQ 拓扑重构
- backend-data 在 lifespan 中自动声明 `digital_employee.events` 全套拓扑（含 DLX/DLQ），删除旧拓扑配置（`bot.topic.exchange` 系列）
- backend-share/rabbitmq-client 拓扑常量从硬编码改为 `os.getenv` 读取，幂等 declare 获取引用，不再自主声明拓扑

### 飞书 Bot 报错屏蔽
- 三层屏蔽：日志过滤器（`[ERROR]` → 中文提示）+ `warnings.filterwarnings`（`RuntimeWarning` 精确过滤）+ monkey-patch 根因修复（`_disconnect()` 异常吞掉，确保 `_reconnect()` 正常执行）
- 跨事件循环 `Task exception was never retrieved` 堆栈不再打印

### 文档
- 更新 `md/rabbitmq收发.md` 反映新架构：模块使用矩阵、Mermaid 拓扑图、代码示例说明

## 涉及文件

| 模块 | 文件 | 变更 |
| :--- | :--- | :--- |
| backend-data | `.env.example`、`config.py`、`main.py`、`message_broker_service.py`、`infrastructure.py` | 拓扑声明迁移 + 旧配置删除 |
| backend-gateway | `bot.py` | 飞书报错三层屏蔽 |
| backend-share | `client.py` | 拓扑常量改为 `os.getenv` 读取 |
| 文档 | `md/rabbitmq收发.md` | 架构图 + 说明更新 |

## 验证

- lint 清零
- gateway 启动日志：`成功建立 RabbitMQ 异步连接` → `消息拓扑建立成功 (exchange=digital_employee.events, dlx=digital_employee.dlx, dlq=outbound_dlq)` → `启动出站消息 AMQP 监听消费者`
- 飞书 WebSocket 报错从英文堆栈变为一行中文提示