### PR TITLE
feat: 权限码读写分级与身份角色互斥校验

### DIFF
--- a/backend-auth/app/api/deps.py
+++ b/backend-auth/app/api/deps.py
@@ -121,7 +121,10 @@ def require_permission(
 
         @router.get(
             "/users",
-            dependencies=[Depends(require_permission("user:read", "user:manage"))],
+            dependencies=[Depends(require_permission(
+                PermissionCode.USER_READONLY,
+                PermissionCode.USER_MANAGE,
+            ))],
         )
         def list_users(): ...
 

--- a/backend-auth/app/api/routes/agents.py
+++ b/backend-auth/app/api/routes/agents.py
@@ -38,7 +38,14 @@ class UpdateAgentPayload(BaseModel):
 @router.get(
     "",
     response_model=ApiResponse,
-    dependencies=[Depends(require_permission(PermissionCode.AGENT_MANAGE))],
+    dependencies=[
+        Depends(
+            require_permission(
+                PermissionCode.AGENT_MANAGE,
+                PermissionCode.AGENT_READONLY,
+            )
+        )
+    ],
 )
 def list_agents(
     page: int = Query(default=1, ge=1),

--- a/backend-auth/app/api/routes/bots.py
+++ b/backend-auth/app/api/routes/bots.py
@@ -35,6 +35,7 @@ class CreateBotPayload(BaseModel):
     app_secret: str = Field(..., min_length=1, max_length=256)
     mode: BotMode = Field(default="test")
     agent_id: str | None = Field(default=None)
+    parent_bot_id: int | None = Field(default=None, description="父级 Bot 主键 ID（表达部门隶属）")
 
 
 class UpdateBotPayload(BaseModel):
@@ -46,12 +47,20 @@ class UpdateBotPayload(BaseModel):
     app_secret: str | None = Field(default=None, min_length=1, max_length=256)
     mode: BotMode | None = Field(default=None)
     agent_id: str | None = Field(default=None)
+    parent_bot_id: int | None = Field(default=None, description="父级 Bot 主键 ID（表达部门隶属）")
 
 
 @router.get(
     "",
     response_model=ApiResponse,
-    dependencies=[Depends(require_permission(PermissionCode.BOT_MANAGE))],
+    dependencies=[
+        Depends(
+            require_permission(
+                PermissionCode.BOT_MANAGE,
+                PermissionCode.BOT_READONLY,
+            )
+        )
+    ],
 )
 def list_bots(
     page: int = Query(default=1, ge=1),
@@ -87,6 +96,7 @@ def create_bot(
         mode=payload.mode,
         agent_id=payload.agent_id,
         created_by=current_user.id,
+        parent_bot_id=payload.parent_bot_id,
     )
     return success_response(result)
 

--- a/backend-auth/app/api/routes/invite_codes.py
+++ b/backend-auth/app/api/routes/invite_codes.py
@@ -42,7 +42,14 @@ def create_invite_code(
 @router.get(
     "",
     response_model=ApiResponse,
-    dependencies=[Depends(require_permission(PermissionCode.INVITE_CODE_MANAGE))],
+    dependencies=[
+        Depends(
+            require_permission(
+                PermissionCode.INVITE_CODE_MANAGE,
+                PermissionCode.INVITE_CODE_READONLY,
+            )
+        )
+    ],
 )
 def list_invite_codes(
     page: int = Query(default=1, ge=1),

--- a/backend-auth/app/api/routes/menus.py
+++ b/backend-auth/app/api/routes/menus.py
@@ -28,7 +28,9 @@ router = APIRouter()
         Depends(
             require_permission(
                 PermissionCode.MENU_MANAGE,
-                PermissionCode.USER_PERMISSION,
+                PermissionCode.MENU_READONLY,
+                PermissionCode.PERMISSION_MANAGE,
+                PermissionCode.PERMISSION_READONLY,
             )
         )
     ],

--- a/backend-auth/app/api/routes/permissions.py
+++ b/backend-auth/app/api/routes/permissions.py
@@ -7,6 +7,8 @@ from auth_utils import PermissionCode
 from fastapi import APIRouter, Depends
 
 from app.api.deps import require_permission
+from app.schemas.auth import UserInfo
+from app.schemas.permission import CreatePermissionRequest
 from app.services.permission_service import PermissionService
 
 router = APIRouter()
@@ -18,8 +20,10 @@ router = APIRouter()
     dependencies=[
         Depends(
             require_permission(
-                PermissionCode.USER_PERMISSION,
+                PermissionCode.PERMISSION_MANAGE,
+                PermissionCode.PERMISSION_READONLY,
                 PermissionCode.MENU_MANAGE,
+                PermissionCode.MENU_READONLY,
             )
         )
     ],
@@ -27,3 +31,38 @@ router = APIRouter()
 def list_permissions() -> dict:
     """返回菜单与角色配置可引用的权限码目录。"""
     return success_response(PermissionService().list_permissions())
+
+
+@router.post(
+    "",
+    response_model=ApiResponse,
+)
+def create_permission(
+    payload: CreatePermissionRequest,
+    _current_user: UserInfo = Depends(
+        require_permission(PermissionCode.PERMISSION_MANAGE)
+    ),
+) -> dict:
+    """动态创建权限码（仅用于菜单可见性与角色授权）。"""
+    result = PermissionService().create_permission(
+        code=payload.code,
+        name=payload.name,
+        description=payload.description,
+        module=payload.module,
+    )
+    return success_response(result)
+
+
+@router.delete(
+    "/{permission_id}",
+    response_model=ApiResponse,
+)
+def delete_permission(
+    permission_id: int,
+    _current_user: UserInfo = Depends(
+        require_permission(PermissionCode.PERMISSION_MANAGE)
+    ),
+) -> dict:
+    """物理删除权限码（无角色/用户引用时）。"""
+    result = PermissionService().delete_permission(permission_id=permission_id)
+    return success_response(result)

--- a/backend-auth/app/api/routes/roles.py
+++ b/backend-auth/app/api/routes/roles.py
@@ -20,8 +20,10 @@ router = APIRouter()
     dependencies=[
         Depends(
             require_permission(
-                PermissionCode.USER_PERMISSION,
+                PermissionCode.PERMISSION_MANAGE,
+                PermissionCode.PERMISSION_READONLY,
                 PermissionCode.USER_MANAGE,
+                PermissionCode.USER_READONLY,
             )
         )
     ],
@@ -39,7 +41,7 @@ def list_roles() -> dict:
 def create_role(
     payload: CreateRoleRequest,
     current_user: UserInfo = Depends(
-        require_permission(PermissionCode.USER_PERMISSION)
+        require_permission(PermissionCode.PERMISSION_MANAGE)
     ),
 ) -> dict:
     """创建自定义角色。"""
@@ -63,7 +65,7 @@ def update_role(
     role_id: int,
     payload: UpdateRoleRequest,
     current_user: UserInfo = Depends(
-        require_permission(PermissionCode.USER_PERMISSION)
+        require_permission(PermissionCode.PERMISSION_MANAGE)
     ),
 ) -> dict:
     """更新角色信息（名称/描述/菜单）。"""
@@ -86,7 +88,7 @@ def update_role(
 def delete_role(
     role_id: int,
     current_user: UserInfo = Depends(
-        require_permission(PermissionCode.USER_PERMISSION)
+        require_permission(PermissionCode.PERMISSION_MANAGE)
     ),
 ) -> dict:
     """删除角色（软删除，内置角色不可删）。"""
@@ -101,7 +103,14 @@ def delete_role(
 @router.get(
     "/{role_id}/menus",
     response_model=ApiResponse,
-    dependencies=[Depends(require_permission(PermissionCode.USER_PERMISSION))],
+    dependencies=[
+        Depends(
+            require_permission(
+                PermissionCode.PERMISSION_MANAGE,
+                PermissionCode.PERMISSION_READONLY,
+            )
+        )
+    ],
 )
 def get_role_menus(
     role_id: int,
@@ -119,7 +128,7 @@ def assign_menus(
     role_id: int,
     payload: AssignMenusRequest,
     current_user: UserInfo = Depends(
-        require_permission(PermissionCode.USER_PERMISSION)
+        require_permission(PermissionCode.PERMISSION_MANAGE)
     ),
 ) -> dict:
     """分配角色菜单（覆盖式）。"""

--- a/backend-auth/app/api/routes/users.py
+++ b/backend-auth/app/api/routes/users.py
@@ -37,7 +37,9 @@ router = APIRouter()
         Depends(
             require_permission(
                 PermissionCode.USER_MANAGE,
-                PermissionCode.USER_PERMISSION,
+                PermissionCode.USER_READONLY,
+                PermissionCode.PERMISSION_MANAGE,
+                PermissionCode.PERMISSION_READONLY,
             )
         )
     ],
@@ -102,7 +104,14 @@ def update_profile(
 @router.get(
     "/vip-levels",
     response_model=ApiResponse,
-    dependencies=[Depends(require_permission(PermissionCode.USER_MANAGE))],
+    dependencies=[
+        Depends(
+            require_permission(
+                PermissionCode.USER_MANAGE,
+                PermissionCode.USER_READONLY,
+            )
+        )
+    ],
 )
 def list_vip_levels() -> dict:
     """返回可配置的业务 VIP 枚举。"""
@@ -156,7 +165,7 @@ def assign_roles(
     user_id: int,
     payload: AssignRolesRequest,
     current_user: UserInfo = Depends(
-        require_permission(PermissionCode.USER_PERMISSION)
+        require_permission(PermissionCode.PERMISSION_MANAGE)
     ),
 ) -> dict:
     """分配用户角色（管理员）。
@@ -265,7 +274,14 @@ def delete_user(
 @router.get(
     "/{user_id}/menus",
     response_model=ApiResponse,
-    dependencies=[Depends(require_permission(PermissionCode.USER_PERMISSION))],
+    dependencies=[
+        Depends(
+            require_permission(
+                PermissionCode.PERMISSION_MANAGE,
+                PermissionCode.PERMISSION_READONLY,
+            )
+        )
+    ],
 )
 def get_user_menus(
     user_id: int,
@@ -283,7 +299,7 @@ def assign_user_menus(
     user_id: int,
     payload: AssignUserMenusRequest,
     current_user: UserInfo = Depends(
-        require_permission(PermissionCode.USER_PERMISSION)
+        require_permission(PermissionCode.PERMISSION_MANAGE)
     ),
 ) -> dict:
     """分配用户独立菜单（覆盖式，管理员）。
@@ -304,7 +320,14 @@ def assign_user_menus(
 @router.get(
     "/{user_id}/permissions",
     response_model=ApiResponse,
-    dependencies=[Depends(require_permission(PermissionCode.USER_PERMISSION))],
+    dependencies=[
+        Depends(
+            require_permission(
+                PermissionCode.PERMISSION_MANAGE,
+                PermissionCode.PERMISSION_READONLY,
+            )
+        )
+    ],
 )
 def get_user_permissions(
     user_id: int,
@@ -322,7 +345,7 @@ def assign_user_permissions(
     user_id: int,
     payload: AssignUserPermissionsRequest,
     current_user: UserInfo = Depends(
-        require_permission(PermissionCode.USER_PERMISSION)
+        require_permission(PermissionCode.PERMISSION_MANAGE)
     ),
 ) -> dict:
     """分配用户独立权限（覆盖式，管理员）。"""

--- a/backend-auth/app/core/config.py
+++ b/backend-auth/app/core/config.py
@@ -6,6 +6,7 @@ HTTP 服务以及通过 backend-share 调用 backend-data 所需的服务地址�
 
 from __future__ import annotations
 
+import os
 from functools import lru_cache
 from pathlib import Path
 from typing import Literal
@@ -28,6 +29,11 @@ def _load_nacos_config_to_environ() -> None:
         from nacos_client import NacosClient
     except ImportError:
         return  # nacos-client 未安装，仅本地开发场景
+
+    # 未配置 Nacos 地址时静默跳过（本地开发/测试场景），
+    # 仅当显式配置了 NACOS_SERVER_ADDR 时才走强制可用路径。
+    if not os.getenv("NACOS_SERVER_ADDR"):
+        return
 
     client = NacosClient.from_env_required()
     client.load_to_environ()

--- a/backend-auth/app/schemas/permission.py
+++ b/backend-auth/app/schemas/permission.py
@@ -1,0 +1,39 @@
+"""权限码管理相关请求/响应 schema。"""
+
+from __future__ import annotations
+
+from auth_utils import PERMISSION_CODE_PATTERN
+from pydantic import BaseModel, Field, field_validator
+
+
+class PermissionItem(BaseModel):
+    """权限码目录项。"""
+
+    id: int
+    code: str
+    name: str
+    description: str = ""
+    module: str | None = None
+
+
+class CreatePermissionRequest(BaseModel):
+    """动态创建权限码请求。"""
+
+    code: str = Field(
+        ...,
+        min_length=3,
+        max_length=128,
+        pattern=PERMISSION_CODE_PATTERN,
+        description="权限码，如 admin:report:manage",
+    )
+    name: str = Field(..., min_length=1, max_length=64, description="权限码名称")
+    description: str = Field(default="", max_length=255, description="权限码描述")
+    module: str | None = Field(default=None, max_length=32, description="所属模块")
+
+    @field_validator("code", mode="before")
+    @classmethod
+    def strip_code(cls, value: object) -> object:
+        """去除权限码首尾空白，避免与前端规范化结果不一致。"""
+        if isinstance(value, str):
+            return value.strip()
+        return value

--- a/backend-auth/app/services/permission_service.py
+++ b/backend-auth/app/services/permission_service.py
@@ -16,3 +16,23 @@ class PermissionService:
     def list_permissions(self) -> list[dict[str, Any]]:
         """列出权限码目录。"""
         return self._data.list_permissions()
+
+    def create_permission(
+        self,
+        *,
+        code: str,
+        name: str,
+        description: str = "",
+        module: str | None = None,
+    ) -> dict[str, Any]:
+        """动态创建权限码。"""
+        return self._data.create_permission(
+            code=code,
+            name=name,
+            description=description,
+            module=module,
+        )
+
+    def delete_permission(self, *, permission_id: int) -> dict[str, Any]:
+        """物理删除权限码。"""
+        return self._data.delete_permission(permission_id)

--- a/backend-auth/app/services/user_service.py
+++ b/backend-auth/app/services/user_service.py
@@ -9,11 +9,12 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from api_common import InvalidCredentialsError, PermissionDeniedError
+from api_common import InvalidCredentialsError, PermissionDeniedError, ValidationError
 from auth_utils import (
     PROTECTED_ROLE_CODES,
     ROLE_CODE_MANAGER,
     ROLE_CODE_SUPER_ADMIN,
+    validate_role_codes,
 )
 from data_client import DataClient, get_data_client
 
@@ -52,6 +53,7 @@ class UserService:
             role_codes=requested_roles,
             actor_role_codes=actor_role_codes,
         )
+        self._ensure_exclusive_roles_valid(requested_roles)
         return self._data.create_user(
             username=username,
             password_hash=hash_password(password),
@@ -81,6 +83,7 @@ class UserService:
             role_codes=role_codes,
             actor_role_codes=actor_role_codes,
         )
+        self._ensure_exclusive_roles_valid(role_codes)
         return self._data.assign_user_roles(
             user_id=user_id,
             role_codes=role_codes,
@@ -196,6 +199,13 @@ class UserService:
             and ROLE_CODE_SUPER_ADMIN not in actor_role_codes
         ):
             raise PermissionDeniedError(message="仅超级管理员可以分配管理员角色")
+
+    @staticmethod
+    def _ensure_exclusive_roles_valid(role_codes: list[str]) -> None:
+        """校验身份角色互斥与独占角色规则（委托共享校验函数）。"""
+        error = validate_role_codes(role_codes)
+        if error is not None:
+            raise ValidationError(message=error)
 
     def reset_user_password(
         self,

--- a/backend-auth/tests/conftest.py
+++ b/backend-auth/tests/conftest.py
@@ -31,8 +31,12 @@ class FakeDataClient:
         self.update_result: dict[str, Any] = {"bot_id": "bot-1", "status": "updated"}
         self.delete_result: dict[str, Any] = {"bot_id": "bot-1", "status": "deleted"}
 
-    def list_bots(self, *, page: int, page_size: int) -> dict[str, Any]:
-        self.calls.append(("list_bots", {"page": page, "page_size": page_size}))
+    def list_bots(
+        self, *, page: int, page_size: int, created_by: int | None = None
+    ) -> dict[str, Any]:
+        self.calls.append(
+            ("list_bots", {"page": page, "page_size": page_size, "created_by": created_by})
+        )
         return self.list_result
 
     def create_bot(self, **payload: Any) -> dict[str, Any]:
@@ -46,6 +50,14 @@ class FakeDataClient:
     def delete_bot(self, bot_id: str) -> dict[str, Any]:
         self.calls.append(("delete_bot", {"bot_id": bot_id}))
         return self.delete_result
+
+    def create_user(self, **payload: Any) -> dict[str, Any]:
+        self.calls.append(("create_user", payload))
+        return {"user_id": 1, "status": "created"}
+
+    def assign_user_roles(self, *, user_id: int, role_codes: list[str], **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(("assign_user_roles", {"user_id": user_id, "role_codes": role_codes}))
+        return {"user_id": user_id, "status": "assigned"}
 
 
 class FakeResponse:

--- a/backend-auth/tests/test_bot_service.py
+++ b/backend-auth/tests/test_bot_service.py
@@ -139,7 +139,9 @@ def test_list_bots_does_not_trigger_reload(
     result = bot_service.list_bots(page=1, page_size=20)
 
     assert result == fake_data_client.list_result
-    assert fake_data_client.calls == [("list_bots", {"page": 1, "page_size": 20})]
+    assert fake_data_client.calls == [
+        ("list_bots", {"page": 1, "page_size": 20, "created_by": None})
+    ]
     assert fake_http_post.calls == []
 
 

--- a/backend-data/backend/app/api/routes/bot.py
+++ b/backend-data/backend/app/api/routes/bot.py
@@ -58,6 +58,7 @@ def create_bot(payload: CreateBotRequest) -> dict:
         mode=payload.mode,
         agent_id=payload.agent_id,
         created_by=payload.created_by,
+        parent_bot_id=payload.parent_bot_id,
     )
     return success_response(result)
 

--- a/backend-data/backend/app/api/routes/identity.py
+++ b/backend-data/backend/app/api/routes/identity.py
@@ -24,6 +24,7 @@ from app.schemas.identity import (
     ConsumeIdentityRateLimitsRequest,
     CreateIdentityInviteCodeRequest,
     CreateIdentityMenuRequest,
+    CreateIdentityPermissionRequest,
     CreateIdentityRoleRequest,
     CreateIdentityUserRequest,
     DeleteIdentityRoleRequest,
@@ -509,6 +510,28 @@ def list_permissions(
     return success_response(PermissionService(session).list_permissions())
 
 
+@router.post("/permissions", response_model=ApiResponse)
+def create_permission(
+    payload: CreateIdentityPermissionRequest,
+    session: Session = Depends(get_core_db_session),
+) -> dict:
+    """动态创建权限码（仅用于菜单可见性与角色授权）。"""
+    return success_response(
+        PermissionService(session).create_permission(**payload.model_dump())
+    )
+
+
+@router.delete("/permissions/{permission_id}", response_model=ApiResponse)
+def delete_permission(
+    permission_id: int,
+    session: Session = Depends(get_core_db_session),
+) -> dict:
+    """物理删除权限码（无角色/用户引用时）。"""
+    return success_response(
+        PermissionService(session).delete_permission(permission_id=permission_id)
+    )
+
+
 @router.post("/invite-codes", response_model=ApiResponse)
 def create_invite_code(
     payload: CreateIdentityInviteCodeRequest,
@@ -577,4 +600,4 @@ def delete_invite_code(
 ) -> dict:
     """删除邀请码。"""
     InviteCodeService().delete(code=code)
-    return success_response(None)
+    return success_response({"code": code, "deleted": True})

--- a/backend-data/backend/app/core/config.py
+++ b/backend-data/backend/app/core/config.py
@@ -1,3 +1,4 @@
+import os
 from functools import lru_cache
 from pathlib import Path
 from typing import Literal
@@ -23,6 +24,11 @@ def _load_nacos_config_to_environ() -> None:
         from nacos_client import NacosClient
     except ImportError:
         return  # nacos-client 未安装，仅本地开发场景
+
+    # 未配置 Nacos 地址时静默跳过（本地开发/测试场景），
+    # 仅当显式配置了 NACOS_SERVER_ADDR 时才走强制可用路径。
+    if not os.getenv("NACOS_SERVER_ADDR"):
+        return
 
     client = NacosClient.from_env_required()
     client.load_to_environ()

--- a/backend-data/backend/app/main.py
+++ b/backend-data/backend/app/main.py
@@ -13,6 +13,7 @@ from fastapi import FastAPI, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
+from loguru import logger
 from observability import TraceMiddleware, TraceService
 from psycopg2 import errorcodes
 from sqlalchemy.exc import ProgrammingError

--- a/backend-data/backend/app/schemas/bot.py
+++ b/backend-data/backend/app/schemas/bot.py
@@ -21,6 +21,7 @@ class CreateBotRequest(BaseModel):
     mode: BotMode = Field(default="test")
     agent_id: str | None = Field(default=None)
     created_by: int | None = Field(default=None)
+    parent_bot_id: int | None = Field(default=None, description="父级 Bot 主键 ID（表达部门隶属）")
 
 
 class UpdateBotRequest(BaseModel):
@@ -32,3 +33,4 @@ class UpdateBotRequest(BaseModel):
     app_secret: str | None = Field(default=None, min_length=1, max_length=256)
     mode: BotMode | None = Field(default=None)
     agent_id: str | None = Field(default=None)
+    parent_bot_id: int | None = Field(default=None, description="父级 Bot 主键 ID（表达部门隶属）")

--- a/backend-data/backend/app/schemas/identity.py
+++ b/backend-data/backend/app/schemas/identity.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel, Field, model_validator
+from auth_utils import PERMISSION_CODE_PATTERN
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 NON_NULLABLE_MENU_UPDATE_FIELDS = frozenset(
     {"parent_id", "menu_type", "title", "sort", "visible"}
@@ -267,6 +268,28 @@ class UpdateIdentityMenuRequest(BaseModel):
         if invalid_fields:
             raise ValueError(f"菜单字段不能设为空：{', '.join(invalid_fields)}")
         return self
+
+
+class CreateIdentityPermissionRequest(BaseModel):
+    """动态创建权限码。"""
+
+    code: str = Field(
+        ...,
+        min_length=3,
+        max_length=128,
+        pattern=PERMISSION_CODE_PATTERN,
+    )
+    name: str = Field(..., min_length=1, max_length=64)
+    description: str = Field(default="", max_length=255)
+    module: str | None = Field(default=None, max_length=32)
+
+    @field_validator("code", mode="before")
+    @classmethod
+    def strip_code(cls, value: object) -> object:
+        """去除权限码首尾空白，与 backend-auth 侧规范化保持一致。"""
+        if isinstance(value, str):
+            return value.strip()
+        return value
 
 
 class CreateIdentityInviteCodeRequest(BaseModel):

--- a/backend-data/backend/app/services/bot_service.py
+++ b/backend-data/backend/app/services/bot_service.py
@@ -24,12 +24,13 @@ from app.models.agent import Agent
 from app.models.bot import Bot
 from app.models.user import User
 from sqlalchemy import func
+from sqlalchemy.orm import aliased
 
 # 可空字段白名单：这些字段允许显式传入 None 来置空（与“未传字段”区分，
 # 后者由 ``model_dump(exclude_unset=True)`` 在路由层过滤掉）。
 # 命中白名单的字段即便值为 None 也会 ``setattr``；其他字段维持
 # ``value is not None`` 的旧语义，避免必填字段（如 app_secret）被误传 null 落库。
-NULLABLE_FIELDS: frozenset[str] = frozenset({"agent_id"})
+NULLABLE_FIELDS: frozenset[str] = frozenset({"agent_id", "parent_bot_id"})
 
 
 def _bot_to_dict(
@@ -39,6 +40,7 @@ def _bot_to_dict(
     created_by_name: str | None = None,
     agent_name: str | None = None,
     creator_vip_level: int | None = None,
+    parent_bot_name: str | None = None,
 ) -> dict[str, Any]:
     """将 Bot ORM 对象转换为字典。
 
@@ -49,6 +51,7 @@ def _bot_to_dict(
         created_by_name: 创建者的显示名称/用户名（联查时提供）。
         agent_name: 关联 Agent 的名称（联查时提供）。
         creator_vip_level: 创建者的 VIP 等级（Gateway 路由用）。
+        parent_bot_name: 父级 Bot 的名称（联查时提供，表达部门隶属）。
     """
     return {
         "id": bot.id,
@@ -61,6 +64,8 @@ def _bot_to_dict(
         "status": bot.status,
         "agent_id": bot.agent_id,
         "agent_name": agent_name,
+        "parent_bot_id": bot.parent_bot_id,
+        "parent_bot_name": parent_bot_name,
         "created_by": bot.created_by,
         "created_by_name": created_by_name,
         "creator_vip_level": creator_vip_level or 0,
@@ -84,6 +89,7 @@ class BotService:
     ) -> dict[str, Any]:
         """分页查询未删除的 Bot 列表（前端管理页用，app_secret 脱敏，联查创建者）。"""
         offset = (page - 1) * page_size
+        parent_alias = aliased(Bot)
         with self._db.session() as session:
             query = (
                 session.query(
@@ -91,9 +97,11 @@ class BotService:
                     func.coalesce(User.nickname, User.username).label("creator_name"),
                     func.coalesce(Agent.name, Bot.agent_id).label("agent_name"),
                     User.vip_level,
+                    parent_alias.name.label("parent_bot_name"),
                 )
                 .outerjoin(User, Bot.created_by == User.id)
                 .outerjoin(Agent, Bot.agent_id == Agent.agent_id)
+                .outerjoin(parent_alias, Bot.parent_bot_id == parent_alias.id)
                 .filter(Bot.deleted_at.is_(None))
             )
             if created_by is not None:
@@ -112,8 +120,9 @@ class BotService:
                     created_by_name=creator_name,
                     agent_name=agent_name,
                     creator_vip_level=vip_level,
+                    parent_bot_name=parent_bot_name,
                 )
-                for bot, creator_name, agent_name, vip_level in rows
+                for bot, creator_name, agent_name, vip_level, parent_bot_name in rows
             ]
             return {
                 "items": items,
@@ -124,6 +133,7 @@ class BotService:
 
     def get_bot(self, *, bot_id: str) -> dict[str, Any]:
         """获取单个 Bot 详情。"""
+        parent_alias = aliased(Bot)
         with self._db.session() as session:
             row = (
                 session.query(
@@ -131,21 +141,24 @@ class BotService:
                     func.coalesce(User.nickname, User.username).label("creator_name"),
                     func.coalesce(Agent.name, Bot.agent_id).label("agent_name"),
                     User.vip_level,
+                    parent_alias.name.label("parent_bot_name"),
                 )
                 .outerjoin(User, Bot.created_by == User.id)
                 .outerjoin(Agent, Bot.agent_id == Agent.agent_id)
+                .outerjoin(parent_alias, Bot.parent_bot_id == parent_alias.id)
                 .filter(Bot.bot_id == bot_id, Bot.deleted_at.is_(None))
                 .first()
             )
             if row is None:
                 raise ResourceNotFoundError(message=f"Bot '{bot_id}' 不存在")
-            bot, creator_name, agent_name, vip_level = row
+            bot, creator_name, agent_name, vip_level, parent_bot_name = row
             return _bot_to_dict(
                 bot,
                 mask_secret=True,
                 created_by_name=creator_name,
                 agent_name=agent_name,
                 creator_vip_level=vip_level,
+                parent_bot_name=parent_bot_name,
             )
 
     def list_active_bots(self) -> list[dict[str, Any]]:
@@ -176,6 +189,7 @@ class BotService:
         mode: str = "test",
         agent_id: str | None = None,
         created_by: int | None = None,
+        parent_bot_id: int | None = None,
     ) -> dict[str, Any]:
         """创建 Bot。"""
         with self._db.session() as session:
@@ -189,6 +203,13 @@ class BotService:
                     message=f"Bot '{bot_id}' 已存在",
                 )
 
+            if parent_bot_id is not None:
+                parent = session.get(Bot, parent_bot_id)
+                if parent is None or parent.deleted_at is not None:
+                    raise ResourceNotFoundError(
+                        message=f"父级 Bot(id={parent_bot_id}) 不存在",
+                    )
+
             bot = Bot(
                 bot_id=bot_id,
                 name=name,
@@ -199,6 +220,7 @@ class BotService:
                 status=1,
                 agent_id=agent_id,
                 created_by=created_by,
+                parent_bot_id=parent_bot_id,
             )
             session.add(bot)
             session.commit()

--- a/backend-data/backend/app/services/identity_auth_service.py
+++ b/backend-data/backend/app/services/identity_auth_service.py
@@ -24,6 +24,7 @@ from auth_utils import (
     USER_PROFILE_ROUTE_PATH,
     MenuType,
     VipLevel,
+    expand_manage_to_readonly,
     get_vip_display,
 )
 from sqlalchemy import or_, select, update
@@ -434,7 +435,13 @@ class IdentityAuthService:
         role_codes: list[str],
         permission_codes: list[str],
     ) -> dict[int, dict[str, int | str | bool | None]]:
-        """按用户运行时快照筛选可见菜单。"""
+        """按用户运行时快照筛选可见菜单。
+
+        菜单 permission 绑定 readonly 码（最低可见权限）；manage 是 readonly
+        的超集，因此持有 manage 权限码的用户也应看到绑 readonly 码的菜单。
+        """
+        # manage 是 readonly 的超集：菜单绑 readonly 码，持有 manage 码的用户也应可见。
+        effective_codes = expand_manage_to_readonly(permission_codes)
         statement = select(
             Menu.id,
             Menu.parent_id,
@@ -480,7 +487,7 @@ class IdentityAuthService:
                     or_(direct_menu_exists, role_menu_exists),
                     or_(
                         Menu.permission.is_(None),
-                        Menu.permission.in_(permission_codes),
+                        Menu.permission.in_(effective_codes),
                     ),
                 )
                 .order_by(Menu.sort, Menu.id)

--- a/backend-data/backend/app/services/identity_permission_service.py
+++ b/backend-data/backend/app/services/identity_permission_service.py
@@ -1,15 +1,18 @@
-"""backend-data 内部权限目录查询服务。"""
+"""backend-data 内部权限目录查询与维护服务。"""
 
 from __future__ import annotations
 
+from api_common import ConflictError, DuplicateResourceError, ResourceNotFoundError
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from app.models.permission import Permission
+from app.models.menu import Menu
+from app.models.permission import Permission, RolePermission
+from app.models.user_permission import UserPermission
 
 
 class PermissionService:
-    """提供管理端可选择的规范权限码目录。"""
+    """提供管理端可选择的规范权限码目录，并支持动态新增/删除权限码。"""
 
     def __init__(self, session: Session) -> None:
         self._session = session
@@ -33,3 +36,94 @@ class PermissionService:
             }
             for permission in permissions
         ]
+
+    def create_permission(
+        self,
+        *,
+        code: str,
+        name: str,
+        description: str = "",
+        module: str | None = None,
+    ) -> dict:
+        """新建权限码。
+
+        动态新建的权限码仅用于菜单可见性与角色授权，不参与后端接口鉴权
+        （接口鉴权仍依赖 ``auth-utils`` 的静态 ``PermissionCode`` 枚举）。
+
+        Raises:
+            DuplicateResourceError: 权限码已存在。
+        """
+        existing = self._session.scalar(
+            select(Permission.id).where(Permission.code == code).limit(1)
+        )
+        if existing is not None:
+            raise DuplicateResourceError(message=f"权限码已存在：{code}")
+
+        permission = Permission(
+            code=code,
+            name=name,
+            description=description,
+            module=module,
+        )
+        self._session.add(permission)
+        self._session.flush()
+        result = self._to_dict(permission)
+        self._session.commit()
+        return result
+
+    def delete_permission(self, *, permission_id: int) -> dict:
+        """物理删除权限码。
+
+        删除前校验该权限码未被任何角色、用户或菜单引用，否则拒绝删除，
+        避免遗留悬空引用导致菜单/授权失效。
+
+        Raises:
+            ResourceNotFoundError: 权限码不存在。
+        """
+        permission = self._session.get(Permission, permission_id)
+        if permission is None:
+            raise ResourceNotFoundError(message="权限码不存在")
+
+        # 校验无角色引用
+        role_ref = self._session.scalar(
+            select(RolePermission.role_id)
+            .where(RolePermission.permission_id == permission_id)
+            .limit(1)
+        )
+        if role_ref is not None:
+            raise ConflictError(message="该权限码已被角色引用，请先解除关联")
+
+        # 校验无用户运行时权限快照引用
+        user_ref = self._session.scalar(
+            select(UserPermission.user_id)
+            .where(UserPermission.permission_id == permission_id)
+            .limit(1)
+        )
+        if user_ref is not None:
+            raise ConflictError(message="该权限码已被用户引用，请先解除关联")
+
+        # 校验无菜单 permission 字段引用（menus.permission 为普通字符串列，无外键约束）
+        menu_ref = self._session.scalar(
+            select(Menu.id)
+            .where(
+                Menu.permission == permission.code,
+                Menu.deleted_at.is_(None),
+            )
+            .limit(1)
+        )
+        if menu_ref is not None:
+            raise ConflictError(message="该权限码已被菜单引用，请先解除关联")
+
+        self._session.delete(permission)
+        self._session.commit()
+        return {"permission_id": permission_id, "deleted": True}
+
+    @staticmethod
+    def _to_dict(permission: Permission) -> dict:
+        return {
+            "id": permission.id,
+            "code": permission.code,
+            "name": permission.name,
+            "description": permission.description,
+            "module": permission.module,
+        }

--- a/backend-data/backend/app/services/identity_role_service.py
+++ b/backend-data/backend/app/services/identity_role_service.py
@@ -16,6 +16,7 @@ from auth_utils import (
     RESERVED_ROLE_CODES,
     ROLE_CODE_MANAGER,
     ROLE_CODE_SUPER_ADMIN,
+    expand_manage_to_readonly,
 )
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
@@ -373,7 +374,10 @@ class RoleService:
         permission_codes = {
             menu.permission for menu in menus if menu.permission is not None
         }
-        unauthorized_codes = sorted(permission_codes - set(actor_permission_codes))
+        # manage 是 readonly 的超集：持有 xxx:manage 的操作者可分配绑 xxx:readonly
+        # 的菜单，避免“拥有管理权却无法分配只读菜单”的误判。
+        actor_scope = expand_manage_to_readonly(actor_permission_codes)
+        unauthorized_codes = sorted(permission_codes - actor_scope)
         if unauthorized_codes:
             raise PermissionDeniedError(
                 message=f"不能授予超出自身范围的权限：{', '.join(unauthorized_codes)}"

--- a/backend-data/backend/app/services/identity_user_service.py
+++ b/backend-data/backend/app/services/identity_user_service.py
@@ -20,7 +20,9 @@ from auth_utils import (
     ROLE_CODE_MANAGER,
     ROLE_CODE_SUPER_ADMIN,
     VipLevel,
+    expand_manage_to_readonly,
     get_vip_display,
+    validate_role_codes,
 )
 from sqlalchemy import select
 from sqlalchemy.orm import Session, selectinload
@@ -122,6 +124,9 @@ class UserService:
             role_codes=requested_role_codes,
             actor_role_codes=actor_role_codes,
         )
+        role_error = validate_role_codes(requested_role_codes)
+        if role_error is not None:
+            raise ValidationError(message=role_error)
         if ROLE_CODE_MANAGER in requested_role_codes and is_vip:
             raise ValidationError(message="管理员身份不能同时配置业务 VIP")
 
@@ -233,6 +238,9 @@ class UserService:
             role_codes=role_codes,
             actor_role_codes=actor_role_codes,
         )
+        role_error = validate_role_codes(role_codes)
+        if role_error is not None:
+            raise ValidationError(message=role_error)
 
         user = self._session.get(User, user_id)
         if user is None or user.deleted_at is not None:
@@ -699,7 +707,10 @@ class UserService:
         """禁止普通管理员授予超出自身范围的权限。"""
         if ROLE_CODE_SUPER_ADMIN in actor_role_codes:
             return
-        unauthorized_codes = sorted(permission_codes - set(actor_permission_codes))
+        # manage 是 readonly 的超集：持有 xxx:manage 的操作者可分配 xxx:readonly，
+        # 避免“拥有管理权却无法分配只读权限”的误判。
+        actor_scope = expand_manage_to_readonly(actor_permission_codes)
+        unauthorized_codes = sorted(permission_codes - actor_scope)
         if unauthorized_codes:
             raise PermissionDeniedError(
                 message=f"不能授予超出自身范围的权限：{', '.join(unauthorized_codes)}"

--- a/backend-data/backend/tests/conftest.py
+++ b/backend-data/backend/tests/conftest.py
@@ -23,7 +23,9 @@ from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
 from app.core.database import Base
+from app.models.agent import Agent
 from app.models.bot import Bot
+from app.models.user import User
 from app.services.bot_service import BotService
 
 
@@ -35,10 +37,17 @@ def sqlite_engine() -> Generator[Engine, None, None]:
         connect_args={"check_same_thread": False},
         poolclass=StaticPool,
     )
-    # 只创建 bots 表，避免其它模型（User/Role 等）的 FK 与 relationship 干扰。
-    Base.metadata.create_all(engine, tables=[Bot.__table__])
+    # list_bots 联表 users / agents 展示创建者与 Agent 名称，需一并创建；
+    # 其余模型（Role 等）不涉及，仍不创建以免 FK/relationship 干扰。
+    Base.metadata.create_all(
+        engine,
+        tables=[User.__table__, Agent.__table__, Bot.__table__],
+    )
     yield engine
-    Base.metadata.drop_all(engine, tables=[Bot.__table__])
+    Base.metadata.drop_all(
+        engine,
+        tables=[Bot.__table__, Agent.__table__, User.__table__],
+    )
     engine.dispose()
 
 

--- a/backend-data/backend/tests/test_bot_service.py
+++ b/backend-data/backend/tests/test_bot_service.py
@@ -121,6 +121,45 @@ class TestCreateBot:
             assert len(deleted) == 1
             assert decrypt(active[0].app_secret) == _ANOTHER_SECRET
 
+    def test_create_with_parent_bot_id(
+        self, bot_service: BotService, db_session_factory
+    ) -> None:
+        """create 传入 parent_bot_id 应正确落库并回显父级 ID。"""
+        parent = bot_service.create_bot(
+            bot_id="parent-1",
+            name="父级部门",
+            platform="feishu",
+            app_id="app-1",
+            app_secret=_PLAIN_SECRET,
+        )
+        child = bot_service.create_bot(
+            bot_id="child-1",
+            name="子 Bot",
+            platform="feishu",
+            app_id="app-2",
+            app_secret=_ANOTHER_SECRET,
+            parent_bot_id=parent["id"],
+        )
+        assert child["parent_bot_id"] == parent["id"]
+
+        with db_session_factory() as session:
+            row = session.query(Bot).filter(Bot.bot_id == "child-1").one()
+            assert row.parent_bot_id == parent["id"]
+
+    def test_create_with_nonexistent_parent_raises(
+        self, bot_service: BotService, db_session_factory
+    ) -> None:
+        """parent_bot_id 指向不存在的 Bot 时应抛 ResourceNotFoundError。"""
+        with pytest.raises(ResourceNotFoundError):
+            bot_service.create_bot(
+                bot_id="orphan-1",
+                name="孤儿",
+                platform="feishu",
+                app_id="app-1",
+                app_secret=_PLAIN_SECRET,
+                parent_bot_id=999999,
+            )
+
 
 # ── update_bot：加密更新 ──────────────────────────────────────────
 
@@ -262,6 +301,31 @@ class TestList:
         assert "alive-1" in bot_ids
         assert "dead-1" not in bot_ids
         assert result["total"] == 1
+
+    def test_list_bots_includes_parent_bot_name(
+        self, bot_service: BotService, db_session_factory
+    ) -> None:
+        """list_bots 应联查并返回父级 Bot 的名称（表达部门隶属）。"""
+        parent = bot_service.create_bot(
+            bot_id="dept-1",
+            name="技术部",
+            platform="feishu",
+            app_id="app-1",
+            app_secret=_PLAIN_SECRET,
+        )
+        bot_service.create_bot(
+            bot_id="dept-child-1",
+            name="后端组",
+            platform="feishu",
+            app_id="app-2",
+            app_secret=_ANOTHER_SECRET,
+            parent_bot_id=parent["id"],
+        )
+
+        result = bot_service.list_bots(page=1, page_size=10)
+        child = next(b for b in result["items"] if b["bot_id"] == "dept-child-1")
+        assert child["parent_bot_id"] == parent["id"]
+        assert child["parent_bot_name"] == "技术部"
 
 
 # ── delete_bot：软删除 + 幂等性 ──────────────────────────────────

--- a/backend-data/backend/tests/test_identity_auth_menus.py
+++ b/backend-data/backend/tests/test_identity_auth_menus.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Generator
 
 import pytest
+from auth_utils import expand_manage_to_readonly, validate_role_codes
 from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session, sessionmaker
@@ -135,3 +136,101 @@ def test_current_user_context_includes_role_menus_when_user_menu_snapshot_is_sta
         "admin:employee:manage",
     ]
     assert {menu["id"] for menu in context["menus"]} == {1101, 2005, 2006}
+
+
+def test_expand_manage_to_readonly_covers_manage_naming() -> None:
+    """manage 权限码应扩展出对应的 readonly 变体。"""
+    expanded = expand_manage_to_readonly(
+        ["admin:menu:manage", "admin:permission:manage", "admin:bot:manage"]
+    )
+    assert "admin:menu:readonly" in expanded
+    assert "admin:permission:readonly" in expanded
+    assert "admin:bot:readonly" in expanded
+    # 原始权限码始终保留
+    assert "admin:menu:manage" in expanded
+    assert "admin:permission:manage" in expanded
+    # 不得产生 xxx:manage:readonly 这类不存在的冗余变体
+    assert "admin:menu:manage:readonly" not in expanded
+    assert "admin:bot:manage:readonly" not in expanded
+
+
+def test_expand_manage_to_readonly_keeps_non_manage_codes() -> None:
+    """非 :manage 后缀的权限码（如数据中台、日志）应原样保留，不追加 readonly。"""
+    expanded = expand_manage_to_readonly(
+        ["admin:data_platform:dashboard", "admin:observability:log:view"]
+    )
+    assert expanded == {"admin:data_platform:dashboard", "admin:observability:log:view"}
+
+
+def test_validate_role_codes_identity_mutual_exclusion() -> None:
+    """身份角色之间互斥，同时出现多个身份角色应返回错误。"""
+    assert validate_role_codes(["user", "manager"]) is not None
+    assert validate_role_codes(["manager", "super_admin"]) is not None
+
+
+def test_validate_role_codes_manager_exclusive() -> None:
+    """manager 独占，不能叠加自定义角色。"""
+    assert validate_role_codes(["manager", "editor"]) is not None
+
+
+def test_validate_role_codes_user_plus_custom_allowed() -> None:
+    """user 可叠加自定义角色。"""
+    assert validate_role_codes(["user", "editor"]) is None
+
+
+def test_validate_role_codes_custom_multi_allowed() -> None:
+    """多个自定义角色可叠加。"""
+    assert validate_role_codes(["editor", "auditor"]) is None
+
+
+def test_validate_role_codes_empty_and_single_allowed() -> None:
+    """空列表或单角色均合法。"""
+    assert validate_role_codes([]) is None
+    assert validate_role_codes(["user"]) is None
+    assert validate_role_codes(["manager"]) is None
+
+
+def test_menu_bound_to_readonly_is_visible_to_manage_holder(
+    identity_session_factory: sessionmaker[Session],
+) -> None:
+    """菜单绑 readonly 码时，持有对应 manage 码的用户也应看到该菜单。"""
+    with identity_session_factory() as session:
+        user = User(
+            id=1,
+            username="bob",
+            password_hash="hash",
+            status=1,
+            is_vip=False,
+            vip_level=0,
+        )
+        role = Role(id=10, code="manager", name="Manager", is_builtin=False)
+        manage_permission = Permission(
+            id=101,
+            code="admin:bot:manage",
+            name="Bot Manage",
+        )
+        bot_menu = Menu(
+            id=2006,
+            parent_id=0,
+            menu_type=2,
+            title="Bot管理",
+            path="/bots",
+            permission="admin:bot:readonly",
+            sort=3,
+            visible=True,
+        )
+        role.permissions = [manage_permission]
+        role.menus = [bot_menu]
+        user.roles = [role]
+        user.menus = []
+        user.permissions = []
+        session.add(user)
+        session.commit()
+
+        service = IdentityAuthService(session)
+        service._sessions = _FakeSessions()
+
+        context = service.get_current_user_context("valid-token")
+
+    # 持有 admin:bot:manage 的用户应看到绑 admin:bot:readonly 的菜单
+    assert {menu["id"] for menu in context["menus"]} == {2006}

--- a/backend-share/auth-utils/src/auth_utils/__init__.py
+++ b/backend-share/auth-utils/src/auth_utils/__init__.py
@@ -12,7 +12,9 @@ from auth_utils.domain import (
     AVATAR_CONTENT_TYPES,
     AVATAR_MAX_SIZE_BYTES,
     BUSINESS_VIP_LEVELS,
+    EXCLUSIVE_ROLE_CODES,
     FULL_ACCESS_ROLE_CODES,
+    IDENTITY_ROLE_CODES,
     INVITE_CODE_ALLOWED_PATTERN,
     INVITE_CODE_GENERATED_LENGTH,
     INVITE_CODE_MAX_LENGTH,
@@ -29,8 +31,13 @@ from auth_utils.domain import (
     detect_avatar_content_type,
     get_vip_display,
     is_business_vip_level,
+    validate_role_codes,
 )
-from auth_utils.permissions import PermissionCode
+from auth_utils.permissions import (
+    PERMISSION_CODE_PATTERN,
+    PermissionCode,
+    expand_manage_to_readonly,
+)
 
 __all__ = [
     "ADMIN_ROLE_CODES",
@@ -42,12 +49,15 @@ __all__ = [
     "AuthorizationError",
     "AuthServiceUnavailableError",
     "BUSINESS_VIP_LEVELS",
+    "EXCLUSIVE_ROLE_CODES",
     "FULL_ACCESS_ROLE_CODES",
+    "IDENTITY_ROLE_CODES",
     "INVITE_CODE_ALLOWED_PATTERN",
     "INVITE_CODE_GENERATED_LENGTH",
     "INVITE_CODE_MAX_LENGTH",
     "INVITE_CODE_MIN_LENGTH",
     "MenuType",
+    "PERMISSION_CODE_PATTERN",
     "PermissionCode",
     "PRIVILEGED_ROLE_CODES",
     "PROTECTED_ROLE_CODES",
@@ -58,6 +68,8 @@ __all__ = [
     "USER_PROFILE_ROUTE_PATH",
     "VipLevel",
     "detect_avatar_content_type",
+    "expand_manage_to_readonly",
     "get_vip_display",
     "is_business_vip_level",
+    "validate_role_codes",
 ]

--- a/backend-share/auth-utils/src/auth_utils/domain.py
+++ b/backend-share/auth-utils/src/auth_utils/domain.py
@@ -43,6 +43,13 @@ FULL_ACCESS_ROLE_CODES = frozenset({ROLE_CODE_SUPER_ADMIN})
 PROTECTED_ROLE_CODES = frozenset({ROLE_CODE_SUPER_ADMIN})
 PRIVILEGED_ROLE_CODES = frozenset({ROLE_CODE_SUPER_ADMIN, ROLE_CODE_MANAGER})
 RESERVED_ROLE_CODES = frozenset({ROLE_CODE_SUPER_ADMIN, ROLE_CODE_MANAGER})
+# 身份角色：super_admin / manager / user 三者互斥，一个用户最多持有其一。
+IDENTITY_ROLE_CODES = frozenset(
+    {ROLE_CODE_SUPER_ADMIN, ROLE_CODE_MANAGER, ROLE_CODE_USER}
+)
+# 独占角色：持有后不能再叠加任何其他角色（含自定义角色）。
+# manager 独占；super_admin 全局唯一；user 可叠加自定义角色。
+EXCLUSIVE_ROLE_CODES = frozenset({ROLE_CODE_SUPER_ADMIN, ROLE_CODE_MANAGER})
 BUSINESS_VIP_LEVELS = tuple(
     level for level in VipLevel if VipLevel.VIP1 <= level <= VipLevel.VIP9
 )
@@ -61,6 +68,29 @@ AVATAR_CONTENT_TYPES = frozenset(
     }
 )
 USER_PROFILE_ROUTE_PATH = "/system/user/profile"
+
+
+def validate_role_codes(role_codes: list[str] | set[str]) -> str | None:
+    """校验角色组合是否合法，返回错误消息（None 表示合法）。
+
+    规则：
+    - 身份角色（super_admin / manager / user）之间互斥，最多选一个。
+    - 独占角色（super_admin / manager）不能叠加任何其他角色；
+      user 作为基础身份，允许叠加自定义角色（如 editor）。
+
+    该函数不抛异常，由调用方决定如何映射到各自的异常类型，
+    避免 auth-utils 依赖 api-common 的异常层级。
+    """
+    codes = set(role_codes)
+    if not codes:
+        return None
+    identity = IDENTITY_ROLE_CODES.intersection(codes)
+    if len(identity) > 1:
+        return "身份角色之间互斥，只能选择一个"
+    exclusive = EXCLUSIVE_ROLE_CODES.intersection(codes)
+    if exclusive and len(codes) > 1:
+        return "该角色不能与其他角色同时分配"
+    return None
 
 
 def get_vip_display(level: int | None) -> str:

--- a/backend-share/auth-utils/src/auth_utils/permissions.py
+++ b/backend-share/auth-utils/src/auth_utils/permissions.py
@@ -4,17 +4,43 @@ from __future__ import annotations
 
 from enum import StrEnum
 
+# 权限码统一命名格式：模块以 a-z 开头，冒号分隔，如 ``admin:report:manage``。
+# 与 frontend/src/constants/access-control.ts、UserPermission 表单校验保持一致。
+PERMISSION_CODE_PATTERN = r"^[a-z][a-z0-9_]*:[a-z0-9_:]+$"
+
 
 class PermissionCode(StrEnum):
     """接口授权与菜单可见性共用的权限码。"""
 
     USER_MANAGE = "admin:user:manage"
-    USER_PERMISSION = "admin:user:permission"
+    USER_READONLY = "admin:user:readonly"
+    PERMISSION_MANAGE = "admin:permission:manage"
+    PERMISSION_READONLY = "admin:permission:readonly"
     INVITE_CODE_MANAGE = "admin:invite_code:manage"
+    INVITE_CODE_READONLY = "admin:invite_code:readonly"
     MENU_MANAGE = "admin:menu:manage"
+    MENU_READONLY = "admin:menu:readonly"
     DATA_PLATFORM_DASHBOARD = "admin:data_platform:dashboard"
     DATA_PLATFORM_DATA_ITEMS = "admin:data_platform:data_items"
     DATA_PLATFORM_CONFIG = "admin:data_platform:config"
     BOT_MANAGE = "admin:bot:manage"
+    BOT_READONLY = "admin:bot:readonly"
     AGENT_MANAGE = "admin:agent:manage"
+    AGENT_READONLY = "admin:agent:readonly"
     OBSERVABILITY_LOG_VIEW = "admin:observability:log:view"
+
+
+def expand_manage_to_readonly(permission_codes: list[str] | set[str]) -> set[str]:
+    """把 manage 权限码扩展出对应的 readonly 变体（manage 是 readonly 的超集）。
+
+    仅处理以 ``:manage`` 结尾的权限码，替换为 ``:readonly``；
+    其他形态（如数据中台、日志查看等非 manage/readonly 命名）原样保留。
+
+    返回的集合始终包含原始权限码，且不会产生 ``xxx:manage:readonly``
+    这类不存在的冗余变体。
+    """
+    expanded = set(permission_codes)
+    for code in permission_codes:
+        if code.endswith(":manage"):
+            expanded.add(f"{code[: -len('manage')]}readonly")
+    return expanded

--- a/backend-share/data-client/src/data_client/client.py
+++ b/backend-share/data-client/src/data_client/client.py
@@ -600,6 +600,33 @@ class DataClient:
         """读取权限码目录。"""
         return self._request_list("GET", "/api/v1/identity/permissions")
 
+    def create_permission(
+        self,
+        *,
+        code: str,
+        name: str,
+        description: str = "",
+        module: str | None = None,
+    ) -> dict[str, Any]:
+        """动态创建权限码。"""
+        return self._request_dict(
+            "POST",
+            "/api/v1/identity/permissions",
+            json={
+                "code": code,
+                "name": name,
+                "description": description,
+                "module": module,
+            },
+        )
+
+    def delete_permission(self, permission_id: int) -> dict[str, Any]:
+        """物理删除权限码。"""
+        return self._request_dict(
+            "DELETE",
+            f"/api/v1/identity/permissions/{permission_id}",
+        )
+
     def create_invite_code(
         self,
         *,
@@ -858,6 +885,7 @@ class DataClient:
         mode: str = "test",
         agent_id: str | None = None,
         created_by: int | None = None,
+        parent_bot_id: int | None = None,
     ) -> dict[str, Any]:
         """创建 Bot。"""
         payload: dict[str, Any] = {
@@ -872,6 +900,8 @@ class DataClient:
             payload["agent_id"] = agent_id
         if created_by is not None:
             payload["created_by"] = created_by
+        if parent_bot_id is not None:
+            payload["parent_bot_id"] = parent_bot_id
         return self._request_dict(
             "POST",
             "/api/v1/bots",

--- a/backend-share/data-client/uv.lock
+++ b/backend-share/data-client/uv.lock
@@ -145,7 +145,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "pydantic", specifier = "==2.13.4" },
-    { name = "starlette", specifier = "==0.52.1" },
+    { name = "starlette", specifier = "==1.3.1" },
 ]
 
 [[package]]
@@ -310,15 +310,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.52.1"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
 ]
 
 [[package]]

--- a/frontend/src/api/bot-api.ts
+++ b/frontend/src/api/bot-api.ts
@@ -14,6 +14,8 @@ export interface BotItem {
   status: number;
   agent_id?: string | null;
   agent_name?: string | null;
+  parent_bot_id?: number | null;
+  parent_bot_name?: string | null;
   created_by?: number | null;
   created_by_name?: string | null;
   created_at: string | null;
@@ -35,6 +37,7 @@ export interface CreateBotPayload {
   app_secret: string;
   mode?: BotMode;
   agent_id?: string | null;
+  parent_bot_id?: number | null;
 }
 
 export interface UpdateBotPayload {
@@ -44,6 +47,7 @@ export interface UpdateBotPayload {
   app_secret?: string;
   mode?: BotMode;
   agent_id?: string | null;
+  parent_bot_id?: number | null;
 }
 
 /** 分页查询 Bot 列表 */

--- a/frontend/src/api/permission-api.ts
+++ b/frontend/src/api/permission-api.ts
@@ -8,7 +8,26 @@ export interface PermissionItem {
   module: string | null;
 }
 
+export interface CreatePermissionPayload {
+  code: string;
+  name: string;
+  description?: string;
+  module?: string;
+}
+
 /** 获取服务端定义的规范权限码目录。 */
 export function fetchPermissions(): Promise<PermissionItem[]> {
   return backendAuthRequest.get<PermissionItem[]>('/permissions');
+}
+
+/** 动态创建权限码（仅用于菜单可见性与角色授权）。 */
+export function createPermission(payload: CreatePermissionPayload): Promise<PermissionItem> {
+  return backendAuthRequest.post<PermissionItem>('/permissions', payload);
+}
+
+/** 物理删除权限码（无角色/用户引用时）。 */
+export function deletePermission(
+  permissionId: number,
+): Promise<{ permission_id: number; deleted: boolean }> {
+  return backendAuthRequest.delete(`/permissions/${permissionId}`);
 }

--- a/frontend/src/constants/access-control.ts
+++ b/frontend/src/constants/access-control.ts
@@ -14,14 +14,20 @@ interface VipLevelMap {
 
 interface PermissionCodeMap {
   USER_MANAGE: string;
-  USER_PERMISSION: string;
+  USER_READONLY: string;
+  PERMISSION_MANAGE: string;
+  PERMISSION_READONLY: string;
   INVITE_CODE_MANAGE: string;
+  INVITE_CODE_READONLY: string;
   MENU_MANAGE: string;
+  MENU_READONLY: string;
   DATA_PLATFORM_DASHBOARD: string;
   DATA_PLATFORM_DATA_ITEMS: string;
   DATA_PLATFORM_CONFIG: string;
   BOT_MANAGE: string;
+  BOT_READONLY: string;
   AGENT_MANAGE: string;
+  AGENT_READONLY: string;
   OBSERVABILITY_LOG_VIEW: string;
 }
 
@@ -37,6 +43,19 @@ export const RESERVED_ROLE_CODES: ReadonlySet<string> = new Set([
   ROLE_CODE.MANAGER,
 ]);
 
+/** 身份角色：super_admin / manager / user 三者互斥，一个用户最多持有其一。 */
+export const IDENTITY_ROLE_CODES: ReadonlySet<string> = new Set([
+  ROLE_CODE.SUPER_ADMIN,
+  ROLE_CODE.MANAGER,
+  ROLE_CODE.USER,
+]);
+
+/** 独占角色：持有后不能再叠加任何其他角色（super_admin 全局唯一，manager 独占）。 */
+export const EXCLUSIVE_ROLE_CODES: ReadonlySet<string> = new Set([
+  ROLE_CODE.SUPER_ADMIN,
+  ROLE_CODE.MANAGER,
+]);
+
 export const VIP_LEVEL: Readonly<VipLevelMap> = Object.freeze({
   NORMAL: 0,
   MANAGER: 66,
@@ -45,14 +64,20 @@ export const VIP_LEVEL: Readonly<VipLevelMap> = Object.freeze({
 
 export const PERMISSION_CODE: Readonly<PermissionCodeMap> = Object.freeze({
   USER_MANAGE: 'admin:user:manage',
-  USER_PERMISSION: 'admin:user:permission',
+  USER_READONLY: 'admin:user:readonly',
+  PERMISSION_MANAGE: 'admin:permission:manage',
+  PERMISSION_READONLY: 'admin:permission:readonly',
   INVITE_CODE_MANAGE: 'admin:invite_code:manage',
+  INVITE_CODE_READONLY: 'admin:invite_code:readonly',
   MENU_MANAGE: 'admin:menu:manage',
+  MENU_READONLY: 'admin:menu:readonly',
   DATA_PLATFORM_DASHBOARD: 'admin:data_platform:dashboard',
   DATA_PLATFORM_DATA_ITEMS: 'admin:data_platform:data_items',
   DATA_PLATFORM_CONFIG: 'admin:data_platform:config',
   BOT_MANAGE: 'admin:bot:manage',
+  BOT_READONLY: 'admin:bot:readonly',
   AGENT_MANAGE: 'admin:agent:manage',
+  AGENT_READONLY: 'admin:agent:readonly',
   OBSERVABILITY_LOG_VIEW: 'admin:observability:log:view',
 });
 
@@ -70,6 +95,23 @@ export function hasAnyPermission(
   return (
     hasFullAccessRole(roleCodes)
     || requiredCodes.some((code) => permissionCodes.includes(code))
+  );
+}
+
+/**
+ * 判断用户是否持有指定模块的管理权限（manage）。
+ *
+ * 只读（readonly）权限码不在此列，因此该函数可用于区分「可管理」与「只读」：
+ * 返回 true 时展示新建/编辑/删除等写操作入口，false 时仅保留查看能力。
+ */
+export function hasManagePermission(
+  roleCodes: readonly string[],
+  permissionCodes: readonly string[],
+  manageCode: string,
+): boolean {
+  return (
+    hasFullAccessRole(roleCodes)
+    || permissionCodes.includes(manageCode)
   );
 }
 

--- a/frontend/src/pages/digital-employee/agent/AgentManagement.tsx
+++ b/frontend/src/pages/digital-employee/agent/AgentManagement.tsx
@@ -5,11 +5,22 @@ import type { ColumnsType } from 'antd/es/table';
 import { deleteAgent, fetchAgents, type AgentItem } from '@/api/agent-api';
 import SystemPage from '@/components/system-page/SystemPage';
 import { getRequestErrorMessage } from '@/utils/request';
+import { hasManagePermission, PERMISSION_CODE } from '@/constants/access-control';
+import { useUserStore } from '@/store/user-store';
 import AgentFormModal from './components/AgentFormModal';
 
 const DEFAULT_PAGE_SIZE = 20;
 
 export default function AgentManagement(): React.ReactElement {
+  const currentUser = useUserStore((state) => state.userInfo);
+  /** 是否可管理 Agent（拥有 manage 权限；仅 readonly 时隐藏写操作入口） */
+  const canManage = currentUser !== null
+    && hasManagePermission(
+      currentUser.roles,
+      currentUser.permissions,
+      PERMISSION_CODE.AGENT_MANAGE,
+    );
+
   const [loading, setLoading] = useState(false);
   const [items, setItems] = useState<AgentItem[]>([]);
   const [total, setTotal] = useState(0);
@@ -101,7 +112,12 @@ export default function AgentManagement(): React.ReactElement {
     {
       title: '操作',
       key: 'action',
-      render: (_: unknown, record: AgentItem) => (
+      render: (_: unknown, record: AgentItem) => {
+        // 只读用户不展示任何写操作入口
+        if (!canManage) {
+          return <span>—</span>;
+        }
+        return (
         <span style={{ display: 'inline-flex', gap: 8 }}>
           <Button type="link" size="small" onClick={() => handleEdit(record)}>
             编辑
@@ -119,7 +135,8 @@ export default function AgentManagement(): React.ReactElement {
             </Button>
           </Popconfirm>
         </span>
-      ),
+        );
+      },
     },
   ];
 
@@ -132,9 +149,11 @@ export default function AgentManagement(): React.ReactElement {
           <Button icon={<ReloadOutlined />} onClick={() => void loadData()}>
             刷新
           </Button>
-          <Button type="primary" icon={<PlusOutlined />} onClick={handleCreate}>
-            新建 Agent
-          </Button>
+          {canManage && (
+            <Button type="primary" icon={<PlusOutlined />} onClick={handleCreate}>
+              新建 Agent
+            </Button>
+          )}
         </span>
       }
     >

--- a/frontend/src/pages/digital-employee/bot/BotManagement.tsx
+++ b/frontend/src/pages/digital-employee/bot/BotManagement.tsx
@@ -5,12 +5,23 @@ import type { ColumnsType } from 'antd/es/table';
 import { deleteBot, fetchBots, type BotItem } from '@/api/bot-api';
 import SystemPage from '@/components/system-page/SystemPage';
 import { getRequestErrorMessage } from '@/utils/request';
+import { hasManagePermission, PERMISSION_CODE } from '@/constants/access-control';
+import { useUserStore } from '@/store/user-store';
 import BotFormModal from './components/BotFormModal';
 import styles from './index.module.css';
 
 const DEFAULT_PAGE_SIZE = 20;
 
 export default function BotManagement(): React.ReactElement {
+  const currentUser = useUserStore((state) => state.userInfo);
+  /** 是否可管理 Bot（拥有 manage 权限；仅 readonly 时隐藏写操作入口） */
+  const canManage = currentUser !== null
+    && hasManagePermission(
+      currentUser.roles,
+      currentUser.permissions,
+      PERMISSION_CODE.BOT_MANAGE,
+    );
+
   const [loading, setLoading] = useState(false);
   const [items, setItems] = useState<BotItem[]>([]);
   const [total, setTotal] = useState(0);
@@ -128,6 +139,13 @@ export default function BotManagement(): React.ReactElement {
       },
     },
     {
+      title: '上级部门',
+      dataIndex: 'parent_bot_name',
+      key: 'parent_bot_name',
+      render: (name: string | null | undefined) =>
+        name ? <Tag color="geekblue">{name}</Tag> : <span style={{ color: '#8c8c8c' }}>—</span>,
+    },
+    {
       title: '创建者',
       dataIndex: 'created_by_name',
       key: 'created_by_name',
@@ -143,7 +161,12 @@ export default function BotManagement(): React.ReactElement {
       title: '操作',
       key: 'action',
       width: 150,
-      render: (_, record) => (
+      render: (_, record) => {
+        // 只读用户不展示任何写操作入口
+        if (!canManage) {
+          return <span>—</span>;
+        }
+        return (
         <div style={{ display: 'flex', gap: 8 }}>
           <Button type="link" size="small" onClick={() => handleEdit(record)}>
             编辑
@@ -161,7 +184,8 @@ export default function BotManagement(): React.ReactElement {
             </Button>
           </Popconfirm>
         </div>
-      ),
+        );
+      },
     },
   ];
 
@@ -174,9 +198,11 @@ export default function BotManagement(): React.ReactElement {
           <Button icon={<ReloadOutlined />} onClick={() => void loadData(page, pageSize)}>
             刷新
           </Button>
-          <Button type="primary" icon={<PlusOutlined />} onClick={handleCreate}>
-            新增 Bot
-          </Button>
+          {canManage && (
+            <Button type="primary" icon={<PlusOutlined />} onClick={handleCreate}>
+              新增 Bot
+            </Button>
+          )}
         </div>
       }
     >

--- a/frontend/src/pages/digital-employee/bot/components/BotFormModal.tsx
+++ b/frontend/src/pages/digital-employee/bot/components/BotFormModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
-import { Form, Input, Modal, Select, message } from 'antd';
-import { createBot, updateBot, type BotItem, type CreateBotPayload, type UpdateBotPayload } from '@/api/bot-api';
+import { Form, Input, Modal, Select, TreeSelect, message } from 'antd';
+import { createBot, updateBot, fetchBots, type BotItem, type CreateBotPayload, type UpdateBotPayload } from '@/api/bot-api';
 import { fetchAgents, type AgentItem } from '@/api/agent-api';
 import { getRequestErrorMessage } from '@/utils/request';
 
@@ -11,6 +11,35 @@ interface BotFormModalProps {
   onSuccess: () => void;
 }
 
+interface BotTreeData {
+  title: string;
+  value: number;
+  children?: BotTreeData[];
+}
+
+/** 把 Bot 列表转换为 TreeSelect 树形数据（表达部门隶属关系） */
+function buildBotTree(bots: BotItem[]): BotTreeData[] {
+  const nodes = new Map<number, BotTreeData>();
+  bots.forEach((bot) => {
+    nodes.set(bot.id, {
+      title: `${bot.name} (${bot.bot_id})`,
+      value: bot.id,
+    });
+  });
+  const roots: BotTreeData[] = [];
+  bots.forEach((bot) => {
+    const node = nodes.get(bot.id);
+    if (!node) return;
+    const parent = bot.parent_bot_id ? nodes.get(bot.parent_bot_id) : undefined;
+    if (parent) {
+      parent.children = [...(parent.children ?? []), node];
+    } else {
+      roots.push(node);
+    }
+  });
+  return roots;
+}
+
 export default function BotFormModal({
   open,
   editingBot,
@@ -19,6 +48,7 @@ export default function BotFormModal({
 }: BotFormModalProps): React.ReactElement {
   const [form] = Form.useForm();
   const [agents, setAgents] = useState<AgentItem[]>([]);
+  const [bots, setBots] = useState<BotItem[]>([]);
   const isEditing = Boolean(editingBot);
 
   useEffect(() => {
@@ -26,6 +56,14 @@ export default function BotFormModal({
       void fetchAgents(1, 100)
         .then((res) => {
           setAgents(res.items);
+        })
+        .catch(() => {
+          // 忽略无影响的静默失败
+        });
+
+      void fetchBots(1, 100)
+        .then((res) => {
+          setBots(res.items);
         })
         .catch(() => {
           // 忽略无影响的静默失败
@@ -40,6 +78,7 @@ export default function BotFormModal({
           app_secret: '', // 编辑时密码框留空，若填写则更新
           mode: editingBot.mode,
           agent_id: editingBot.agent_id || undefined,
+          parent_bot_id: editingBot.parent_bot_id || undefined,
         });
       } else {
         form.resetFields();
@@ -61,6 +100,7 @@ export default function BotFormModal({
           app_id: values.app_id,
           mode: values.mode,
           agent_id: values.agent_id || null,
+          parent_bot_id: values.parent_bot_id || null,
         };
         if (values.app_secret) {
           updatePayload.app_secret = values.app_secret;
@@ -76,6 +116,7 @@ export default function BotFormModal({
           app_secret: values.app_secret,
           mode: values.mode,
           agent_id: values.agent_id || null,
+          parent_bot_id: values.parent_bot_id || null,
         };
         await createBot(createPayload);
         message.success('新增机器人成功');
@@ -172,6 +213,21 @@ export default function BotFormModal({
               label: `${agent.name} (${agent.agent_id})`,
               value: agent.agent_id,
             }))}
+          />
+        </Form.Item>
+
+        <Form.Item
+          name="parent_bot_id"
+          label="上级部门"
+          extra="选择该 Bot 所属的上级部门（Bot 树形结构，可选）"
+        >
+          <TreeSelect
+            placeholder="请选择上级部门 (可选)"
+            allowClear
+            showSearch
+            treeNodeFilterProp="title"
+            treeDefaultExpandAll
+            treeData={buildBotTree(bots.filter((b) => b.id !== editingBot?.id))}
           />
         </Form.Item>
       </Form>

--- a/frontend/src/pages/system/menu/MenuManagement.tsx
+++ b/frontend/src/pages/system/menu/MenuManagement.tsx
@@ -44,6 +44,7 @@ import {
 } from '@/api/permission-api';
 import { useUserStore } from '@/store/user-store';
 import { getMenuIcon, MENU_ICON_NAMES } from '@/constants/menu-icons';
+import { hasManagePermission, PERMISSION_CODE } from '@/constants/access-control';
 import { getRequestErrorMessage } from '@/utils/request';
 import SystemPage from '@/components/system-page/SystemPage';
 import styles from './index.module.css';
@@ -184,6 +185,15 @@ export default function MenuManagement(): React.ReactElement {
   const [form] = Form.useForm<MenuFormValues>();
 
   const reloadMenus = useUserStore((state) => state.reloadMenus);
+  const userInfo = useUserStore((state) => state.userInfo);
+
+  /** 是否可管理菜单（拥有 manage 权限；仅 readonly 时隐藏写操作入口） */
+  const canManage = userInfo !== null
+    && hasManagePermission(
+      userInfo.roles,
+      userInfo.permissions,
+      PERMISSION_CODE.MENU_MANAGE,
+    );
 
   /** 表格数据：仅根节点进入 dataSource，子节点通过 children 嵌套 */
   const tableData = useMemo(() => buildTableData(menus), [menus]);
@@ -197,6 +207,9 @@ export default function MenuManagement(): React.ReactElement {
   const loadMenus = useCallback(async (
     isActive: () => boolean = () => true,
   ): Promise<void> => {
+    if (!isActive()) {
+      return;
+    }
     setLoading(true);
     try {
       const [list, permissionList] = await Promise.all([
@@ -455,6 +468,10 @@ export default function MenuManagement(): React.ReactElement {
       width: 154,
       align: 'center',
       render: (_, record) => {
+        // 只读用户不展示任何写操作入口
+        if (!canManage) {
+          return <span className={styles.emptyValue}>—</span>;
+        }
         // 根目录（顶级）不允许删除，避免误删顶层导航结构
         const isRoot = record.parent_id === 0;
         // 有子菜单的节点不允许删除，需先删除子菜单
@@ -549,9 +566,11 @@ export default function MenuManagement(): React.ReactElement {
           >
             刷新
           </Button>
-          <Button type="primary" icon={<PlusOutlined />} onClick={openCreateModal}>
-            新建菜单
-          </Button>
+          {canManage && (
+            <Button type="primary" icon={<PlusOutlined />} onClick={openCreateModal}>
+              新建菜单
+            </Button>
+          )}
         </Space>
       )}
     >
@@ -609,7 +628,7 @@ export default function MenuManagement(): React.ReactElement {
             label="父菜单"
             name="parent_id"
             rules={[{ required: true, message: '请选择父菜单' }]}
-            extra="仅目录可作为父节点；顶级菜单（目录）选「顶级菜单」"
+            extra="仅目录可作为父节点"
           >
             <TreeSelect
               treeData={parentTreeData}
@@ -627,9 +646,8 @@ export default function MenuManagement(): React.ReactElement {
             <Select
               disabled={editingHasChildren}
               options={[
-                { value: 1, label: '目录（含子菜单的容器）' },
-                { value: 2, label: '菜单（实际页面）' },
-                { value: 3, label: '按钮（仅权限点，不显示）' },
+                { value: 1, label: '目录' },
+                { value: 2, label: '菜单' },
               ]}
               placeholder="选择类型"
             />
@@ -650,7 +668,7 @@ export default function MenuManagement(): React.ReactElement {
             label="路由路径"
             name="path"
             rules={[{ max: 255, message: '路径不超过 255 字符' }]}
-            extra="前端路由路径，如 /data-platform/dashboard；目录可留空"
+            extra="如 /data-platform/dashboard；目录可留空"
           >
             <Input placeholder="/system/menu" />
           </Form.Item>
@@ -667,7 +685,7 @@ export default function MenuManagement(): React.ReactElement {
           <Form.Item
             label="图标名"
             name="icon"
-            extra="从前端已注册的 Ant Design 图标中选择；留空则使用默认图标"
+            extra="留空则使用默认图标"
           >
             <Select
               allowClear
@@ -689,7 +707,7 @@ export default function MenuManagement(): React.ReactElement {
           <Form.Item
             label="权限码"
             name="permission"
-            extra="访问该菜单所需权限码；留空表示仅登录可见"
+            extra="留空则登录即可访问，不校验权限"
           >
             <Select
               allowClear

--- a/frontend/src/pages/system/user/invite-code/InviteCode.tsx
+++ b/frontend/src/pages/system/user/invite-code/InviteCode.tsx
@@ -24,6 +24,11 @@ import {
 } from '@/api/invite-code-api';
 import { getRequestErrorMessage } from '@/utils/request';
 import {
+  hasManagePermission,
+  PERMISSION_CODE,
+} from '@/constants/access-control';
+import { useUserStore } from '@/store/user-store';
+import {
   INVITE_CODE_MESSAGE,
   INVITE_CODE_PATTERN,
 } from '@/utils/identity-validation';
@@ -61,6 +66,15 @@ function getErrorMessage(error: unknown): string {
 }
 
 export default function InviteCode(): React.ReactElement {
+  const currentUser = useUserStore((state) => state.userInfo);
+  /** 是否可管理邀请码（拥有 manage 权限；仅 readonly 时隐藏写操作入口） */
+  const canManage = currentUser !== null
+    && hasManagePermission(
+      currentUser.roles,
+      currentUser.permissions,
+      PERMISSION_CODE.INVITE_CODE_MANAGE,
+    );
+
   const [loading, setLoading] = useState<boolean>(false);
   const [page, setPage] = useState<number>(1);
   const [pageSize, setPageSize] = useState<number>(DEFAULT_TABLE_PAGE_SIZE);
@@ -251,21 +265,25 @@ export default function InviteCode(): React.ReactElement {
           >
             复制
           </Button>
-          <Button
-            type="link"
-            size="small"
-            onClick={() => openEditModal(record)}
-          >
-            编辑
-          </Button>
-          <Button
-            type="link"
-            size="small"
-            danger
-            onClick={() => void handleDeleteCode(record)}
-          >
-            删除
-          </Button>
+          {canManage && (
+            <>
+              <Button
+                type="link"
+                size="small"
+                onClick={() => openEditModal(record)}
+              >
+                编辑
+              </Button>
+              <Button
+                type="link"
+                size="small"
+                danger
+                onClick={() => void handleDeleteCode(record)}
+              >
+                删除
+              </Button>
+            </>
+          )}
         </Space>
       ),
     },
@@ -277,9 +295,11 @@ export default function InviteCode(): React.ReactElement {
       actions={(
         <Space>
           <Button onClick={() => void loadInviteCodes()}>刷新</Button>
-          <Button type="primary" onClick={openCreateModal}>
-            新建邀请码
-          </Button>
+          {canManage && (
+            <Button type="primary" onClick={openCreateModal}>
+              新建邀请码
+            </Button>
+          )}
         </Space>
       )}
     >

--- a/frontend/src/pages/system/user/permission/UserPermission.tsx
+++ b/frontend/src/pages/system/user/permission/UserPermission.tsx
@@ -2,13 +2,13 @@ import { useEffect, useMemo, useState } from 'react';
 import {
   Button,
   Card,
-  Checkbox,
   Empty,
   Form,
   Input,
   Modal,
   Popconfirm,
   Radio,
+  Select,
   Space,
   Spin,
   Table,
@@ -40,11 +40,21 @@ import {
 } from '@/api/role-api';
 import { fetchMenus, type MenuItem } from '@/api/menu-api';
 import {
+  createPermission,
+  deletePermission,
+  fetchPermissions,
+  type CreatePermissionPayload,
+  type PermissionItem,
+} from '@/api/permission-api';
+import {
+  hasManagePermission,
+  PERMISSION_CODE,
   RESERVED_ROLE_CODES,
   ROLE_CODE,
 } from '@/constants/access-control';
 import { useUserStore } from '@/store/user-store';
 import { getRequestErrorMessage } from '@/utils/request';
+import { normalizeRoleCodes } from '@/utils/role-validation';
 import SystemPage from '@/components/system-page/SystemPage';
 import {
   createTablePagination,
@@ -110,10 +120,25 @@ interface RoleFormValues {
   description: string;
 }
 
+interface PermissionFormValues {
+  code: string;
+  name: string;
+  description: string;
+  module: string;
+}
+
 export default function UserPermission(): React.ReactElement {
-  const currentUserRoles = useUserStore((state) => state.userInfo?.roles ?? []);
-  const currentUserId = useUserStore((state) => state.userInfo?.id ?? null);
+  const currentUser = useUserStore((state) => state.userInfo);
+  const currentUserRoles = currentUser?.roles ?? [];
+  const currentUserId = currentUser?.id ?? null;
   const canManageManager = currentUserRoles.includes(ROLE_CODE.SUPER_ADMIN);
+  /** 是否可管理权限（拥有 manage 权限；仅 readonly 时隐藏写操作入口） */
+  const canManage = currentUser !== null
+    && hasManagePermission(
+      currentUser.roles,
+      currentUser.permissions,
+      PERMISSION_CODE.PERMISSION_MANAGE,
+    );
 
   // ── 左栏：用户角色分配 ──
   const [users, setUsers] = useState<UserListItem[]>([]);
@@ -146,6 +171,13 @@ export default function UserPermission(): React.ReactElement {
   const [editingRole, setEditingRole] = useState<RoleItem | null>(null);
   const [roleForm] = Form.useForm<RoleFormValues>();
   const [roleSubmitting, setRoleSubmitting] = useState<boolean>(false);
+
+  // ── 权限码管理弹窗 ──
+  const [permissionModalOpen, setPermissionModalOpen] = useState<boolean>(false);
+  const [permissions, setPermissions] = useState<PermissionItem[]>([]);
+  const [permissionsLoading, setPermissionsLoading] = useState<boolean>(false);
+  const [permissionSubmitting, setPermissionSubmitting] = useState<boolean>(false);
+  const [permissionForm] = Form.useForm<PermissionFormValues>();
 
   const menuTreeData = useMemo<TreeDataNode[]>(
     () => convertMenusToTreeData(allMenus),
@@ -393,6 +425,87 @@ export default function UserPermission(): React.ReactElement {
     }
   }
 
+  // ── 权限码管理 ──
+  async function loadPermissions(): Promise<void> {
+    setPermissionsLoading(true);
+    try {
+      const response = await fetchPermissions();
+      setPermissions(response);
+    } catch (error) {
+      message.error(getErrorMessage(error));
+    } finally {
+      setPermissionsLoading(false);
+    }
+  }
+
+  function openPermissionModal(): void {
+    permissionForm.resetFields();
+    setPermissionModalOpen(true);
+    void loadPermissions();
+  }
+
+  function closePermissionModal(): void {
+    setPermissionModalOpen(false);
+    permissionForm.resetFields();
+  }
+
+  async function handlePermissionSubmit(values: PermissionFormValues): Promise<void> {
+    setPermissionSubmitting(true);
+    try {
+      const payload: CreatePermissionPayload = {
+        code: values.code.trim(),
+        name: values.name.trim(),
+        description: values.description?.trim() || undefined,
+        module: values.module?.trim() || undefined,
+      };
+      await createPermission(payload);
+      message.success(`权限码创建成功：${payload.code}`);
+      permissionForm.resetFields();
+      await loadPermissions();
+    } catch (error) {
+      message.error(getErrorMessage(error));
+    } finally {
+      setPermissionSubmitting(false);
+    }
+  }
+
+  async function handleDeletePermission(record: PermissionItem): Promise<void> {
+    try {
+      await deletePermission(record.id);
+      message.success(`权限码 ${record.code} 已删除`);
+      await loadPermissions();
+    } catch (error) {
+      message.error(getErrorMessage(error));
+    }
+  }
+
+  const permissionColumns: ColumnsType<PermissionItem> = [
+    { title: '权限码', dataIndex: 'code', width: 220 },
+    { title: '名称', dataIndex: 'name', width: 140 },
+    { title: '模块', dataIndex: 'module', width: 120, render: (value: string | null) => value || '-' },
+    { title: '描述', dataIndex: 'description', render: (value: string) => value || '-' },
+    {
+      title: '操作',
+      key: 'action',
+      width: 80,
+      align: 'center',
+      render: (_, record) => (
+        <Popconfirm
+          title="确认删除该权限码？"
+          description="删除后不可恢复，请确保已解除角色/用户关联。"
+          onConfirm={() => void handleDeletePermission(record)}
+          okText="删除"
+          cancelText="取消"
+          okButtonProps={{ danger: true }}
+        >
+          <Button type="link" size="small" danger>
+            删除
+          </Button>
+        </Popconfirm>
+      ),
+    },
+  ];
+
   const userColumns: ColumnsType<UserListItem> = [
     { title: '用户名', dataIndex: 'username', width: 140 },
     {
@@ -459,38 +572,38 @@ export default function UserPermission(): React.ReactElement {
             <div className={styles.roleSection}>
               <div className={styles.sectionHeader}>
                 <Text strong>为 {selectedUser.username} 分配角色</Text>
-                <Button
-                  type="primary"
-                  size="small"
-                  loading={userRolesSaving}
-                  disabled={selectedUser.id === currentUserId}
-                  onClick={() => void handleSaveUserRoles()}
-                >
-                  保存角色
-                </Button>
+                {canManage && (
+                  <Button
+                    type="primary"
+                    size="small"
+                    loading={userRolesSaving}
+                    disabled={selectedUser.id === currentUserId}
+                    onClick={() => void handleSaveUserRoles()}
+                  >
+                    保存角色
+                  </Button>
+                )}
               </div>
               {rolesLoading ? (
                 <Spin />
               ) : roles.length === 0 ? (
                 <Empty description="暂无角色" />
               ) : (
-                <Checkbox.Group
+                <Select
+                  mode="multiple"
                   value={userRoleCodes}
-                  disabled={selectedUser.id === currentUserId}
-                  onChange={(values) => {
-                    setUserRoleCodes(
-                      values.filter((v): v is string => typeof v === 'string'),
-                    );
+                  disabled={!canManage || selectedUser.id === currentUserId}
+                  onChange={(values: string[]) => {
+                    setUserRoleCodes(normalizeRoleCodes(values));
                   }}
-                >
-                  <Space orientation="vertical">
-                    {roles.map((role) => (
-                      <Checkbox key={role.code} value={role.code}>
-                        {role.name}（{role.code}）
-                      </Checkbox>
-                    ))}
-                  </Space>
-                </Checkbox.Group>
+                  options={roles.map((role) => ({
+                    label: `${role.name}（${role.code}）`,
+                    value: role.code,
+                  }))}
+                  placeholder="请选择角色"
+                  style={{ width: '100%' }}
+                  allowClear
+                />
               )}
             </div>
 
@@ -498,15 +611,17 @@ export default function UserPermission(): React.ReactElement {
             <div className={styles.userPermSection}>
               <div className={styles.sectionHeader}>
                 <Text strong>用户菜单权限</Text>
-                <Button
-                  type="primary"
-                  size="small"
-                  loading={userMenusSaving}
-                  disabled={userMenusLoading}
-                  onClick={() => void handleSaveUserMenus()}
-                >
-                  保存菜单
-                </Button>
+                {canManage && (
+                  <Button
+                    type="primary"
+                    size="small"
+                    loading={userMenusSaving}
+                    disabled={userMenusLoading}
+                    onClick={() => void handleSaveUserMenus()}
+                  >
+                    保存菜单
+                  </Button>
+                )}
               </div>
               {userMenusLoading ? (
                 <Spin />
@@ -519,6 +634,7 @@ export default function UserPermission(): React.ReactElement {
                   treeData={menuTreeData}
                   checkedKeys={userMenuIds}
                   onCheck={handleUserMenuCheck}
+                  disabled={!canManage}
                 />
               )}
             </div>
@@ -532,14 +648,25 @@ export default function UserPermission(): React.ReactElement {
       <Card className={styles.panel}>
         <div className={styles.roleToolbar}>
           <div className={styles.panelTitle}>角色管理</div>
-          <Button
-            type="primary"
-            icon={<PlusOutlined />}
-            size="small"
-            onClick={openCreateRoleModal}
-          >
-            新建角色
-          </Button>
+          {canManage && (
+            <Space size="small">
+              <Button
+                type="primary"
+                icon={<PlusOutlined />}
+                size="small"
+                onClick={openCreateRoleModal}
+              >
+                新建角色
+              </Button>
+              <Button
+                size="small"
+                icon={<SafetyCertificateOutlined />}
+                onClick={openPermissionModal}
+              >
+                权限码管理
+              </Button>
+            </Space>
+          )}
         </div>
 
         {rolesLoading ? (
@@ -565,39 +692,41 @@ export default function UserPermission(): React.ReactElement {
                     <span className={styles.roleCode}>（{role.code}）</span>
                     {role.is_builtin && <Tag color="orange" className={styles.builtinTag}>内置</Tag>}
                   </Radio>
-                  <Space size={4} className={styles.roleActions}>
-                    <Button
-                      type="link"
-                      size="small"
-                      icon={<EditOutlined />}
-                      onClick={(e) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        openEditRoleModal(role);
-                      }}
-                    />
-                    {!role.is_builtin && (
-                      <Popconfirm
-                        title="确认删除该角色？"
-                        description="删除后不可恢复，请确保已解除用户关联。"
-                        onConfirm={() => void handleDeleteRole(role)}
-                        okText="删除"
-                        cancelText="取消"
-                        okButtonProps={{ danger: true }}
-                      >
-                        <Button
-                          type="link"
-                          size="small"
-                          danger
-                          icon={<DeleteOutlined />}
-                          onClick={(e) => {
-                            e.preventDefault();
-                            e.stopPropagation();
-                          }}
-                        />
-                      </Popconfirm>
-                    )}
-                  </Space>
+                  {canManage && (
+                    <Space size={4} className={styles.roleActions}>
+                      <Button
+                        type="link"
+                        size="small"
+                        icon={<EditOutlined />}
+                        onClick={(e) => {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          openEditRoleModal(role);
+                        }}
+                      />
+                      {!role.is_builtin && (
+                        <Popconfirm
+                          title="确认删除该角色？"
+                          description="删除后不可恢复，请确保已解除用户关联。"
+                          onConfirm={() => void handleDeleteRole(role)}
+                          okText="删除"
+                          cancelText="取消"
+                          okButtonProps={{ danger: true }}
+                        >
+                          <Button
+                            type="link"
+                            size="small"
+                            danger
+                            icon={<DeleteOutlined />}
+                            onClick={(e) => {
+                              e.preventDefault();
+                              e.stopPropagation();
+                            }}
+                          />
+                        </Popconfirm>
+                      )}
+                    </Space>
+                  )}
                 </div>
               ))}
             </Space>
@@ -608,14 +737,16 @@ export default function UserPermission(): React.ReactElement {
           <div className={styles.menuTree}>
             <div className={styles.sectionHeader}>
               <Text strong>为 {selectedRole.name} 分配菜单</Text>
-              <Button
-                type="primary"
-                size="small"
-                loading={roleMenusSaving}
-                onClick={() => void handleSaveRoleMenus()}
-              >
-                保存
-              </Button>
+              {canManage && (
+                <Button
+                  type="primary"
+                  size="small"
+                  loading={roleMenusSaving}
+                  onClick={() => void handleSaveRoleMenus()}
+                >
+                  保存
+                </Button>
+              )}
             </div>
             {menuTreeData.length === 0 ? (
               <Empty description="暂无菜单数据" />
@@ -626,6 +757,7 @@ export default function UserPermission(): React.ReactElement {
                 treeData={menuTreeData}
                 checkedKeys={checkedMenuIds}
                 onCheck={handleMenuCheck}
+                disabled={!canManage}
               />
             )}
           </div>
@@ -692,6 +824,63 @@ export default function UserPermission(): React.ReactElement {
             <Input.TextArea placeholder="可选，描述该角色的职责" rows={3} />
           </Form.Item>
         </Form>
+      </Modal>
+
+      {/* 权限码管理弹窗 */}
+      <Modal
+        open={permissionModalOpen}
+        title="权限码管理"
+        width={720}
+        onCancel={closePermissionModal}
+        footer={null}
+      >
+        <Form<PermissionFormValues>
+          form={permissionForm}
+          layout="inline"
+          onFinish={handlePermissionSubmit}
+          className={styles.permissionForm}
+        >
+          <Form.Item
+            label="权限码"
+            name="code"
+            rules={[
+              { required: true, message: '请输入权限码' },
+              { min: 3, max: 128, message: '权限码长度需在 3-128 之间' },
+              { pattern: /^[a-z][a-z0-9_]*:[a-z0-9_:]+$/, message: '格式如 admin:report:manage' },
+            ]}
+          >
+            <Input placeholder="如 admin:report:manage" style={{ width: 200 }} />
+          </Form.Item>
+          <Form.Item
+            label="名称"
+            name="name"
+            rules={[{ required: true, message: '请输入名称' }]}
+          >
+            <Input placeholder="如 报表管理" style={{ width: 140 }} />
+          </Form.Item>
+          <Form.Item label="模块" name="module">
+            <Input placeholder="如 report" style={{ width: 120 }} />
+          </Form.Item>
+          <Form.Item label="描述" name="description">
+            <Input placeholder="可选" style={{ width: 200 }} />
+          </Form.Item>
+          <Form.Item>
+            <Button type="primary" htmlType="submit" loading={permissionSubmitting}>
+              新建
+            </Button>
+          </Form.Item>
+        </Form>
+
+        <Table<PermissionItem>
+          rowKey="id"
+          columns={permissionColumns}
+          dataSource={permissions}
+          loading={permissionsLoading}
+          size="small"
+          style={{ marginTop: 16 }}
+          pagination={false}
+          scroll={{ y: 360 }}
+        />
       </Modal>
       </div>
     </SystemPage>

--- a/frontend/src/pages/system/user/permission/index.module.css
+++ b/frontend/src/pages/system/user/permission/index.module.css
@@ -120,8 +120,19 @@
   margin-bottom: 12px;
 }
 
+.roleGroupLabel {
+  margin-bottom: 8px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--ant-color-text-secondary);
+}
+
 .emptyHint {
   padding: 24px 0;
+}
+
+.permissionForm :global(.ant-form-item) {
+  margin-bottom: 12px;
 }
 
 @media (max-width: 1024px) {

--- a/frontend/src/pages/system/user/profile/Profile.tsx
+++ b/frontend/src/pages/system/user/profile/Profile.tsx
@@ -214,9 +214,10 @@ export default function Profile(): React.ReactElement {
             onFinish={handleSubmit}
             className={styles.form}
             initialValues={{ password: '', confirmPassword: '' }}
+            autoComplete="off"
           >
             <Form.Item label="昵称" name="nickname">
-              <Input placeholder="请输入昵称" />
+              <Input placeholder="请输入昵称" autoComplete="nickname" />
             </Form.Item>
             <Form.Item
               label="邮箱"
@@ -225,7 +226,7 @@ export default function Profile(): React.ReactElement {
                 { pattern: EMAIL_PATTERN, message: '请输入有效的邮箱地址' },
               ]}
             >
-              <Input placeholder="请输入邮箱" />
+              <Input placeholder="请输入邮箱" autoComplete="email" />
             </Form.Item>
             <Form.Item
               label="手机号"

--- a/frontend/src/pages/system/user/register/UserRegister.tsx
+++ b/frontend/src/pages/system/user/register/UserRegister.tsx
@@ -31,11 +31,14 @@ import {
 import { fetchRoles, type RoleItem } from '@/api/role-api';
 import {
   getVipDisplayFallback,
+  hasManagePermission,
+  PERMISSION_CODE,
   ROLE_CODE,
   VIP_LEVEL,
 } from '@/constants/access-control';
 import { useUserStore } from '@/store/user-store';
 import { getRequestErrorMessage } from '@/utils/request';
+import { normalizeRoleCodes } from '@/utils/role-validation';
 import { PHONE_DIAL_PREFIX } from '@/config/identity-config';
 import {
   EMAIL_PATTERN,
@@ -82,8 +85,16 @@ function getErrorMessage(error: unknown): string {
 }
 
 export default function UserRegister(): React.ReactElement {
-  const currentUserRoles = useUserStore((state) => state.userInfo?.roles ?? []);
+  const currentUser = useUserStore((state) => state.userInfo);
+  const currentUserRoles = currentUser?.roles ?? [];
   const canAssignManager = currentUserRoles.includes(ROLE_CODE.SUPER_ADMIN);
+  /** 是否可管理用户（拥有 manage 权限；仅 readonly 时隐藏写操作入口） */
+  const canManage = currentUser !== null
+    && hasManagePermission(
+      currentUser.roles,
+      currentUser.permissions,
+      PERMISSION_CODE.USER_MANAGE,
+    );
   const [loading, setLoading] = useState<boolean>(false);
   const [users, setUsers] = useState<UserListItem[]>([]);
   const [total, setTotal] = useState<number>(0);
@@ -459,7 +470,12 @@ export default function UserRegister(): React.ReactElement {
       fixed: 'right',
       width: 330,
       align: 'center',
-      render: (_, record) => (
+      render: (_, record) => {
+        // 只读用户不展示任何写操作入口
+        if (!canManage) {
+          return <span>—</span>;
+        }
+        return (
         <Space size={4}>
           <Button type="link" size="small" onClick={() => openAssignModal(record)}>
             分配角色
@@ -512,18 +528,19 @@ export default function UserRegister(): React.ReactElement {
             </Button>
           </Popconfirm>
         </Space>
-      ),
+        );
+      },
     },
   ];
 
   return (
     <SystemPage
       title="用户管理"
-      actions={(
+      actions={canManage ? (
         <Button type="primary" onClick={openCreateModal}>
           新建用户
         </Button>
-      )}
+      ) : null}
     >
       <div className={styles.container}>
 
@@ -625,7 +642,11 @@ export default function UserRegister(): React.ReactElement {
               placeholder="请选择角色"
               allowClear
               onChange={(nextRoleCodes: string[]) => {
-                if (nextRoleCodes.includes(ROLE_CODE.MANAGER)) {
+                const normalized = normalizeRoleCodes(nextRoleCodes);
+                if (normalized.length !== nextRoleCodes.length) {
+                  createForm.setFieldsValue({ roleCodes: normalized });
+                }
+                if (normalized.includes(ROLE_CODE.MANAGER)) {
                   createForm.setFieldsValue({
                     isVip: false,
                     vipLevel: undefined,
@@ -706,7 +727,9 @@ export default function UserRegister(): React.ReactElement {
         <Select
           mode="multiple"
           value={assignRoleCodes}
-          onChange={setAssignRoleCodes}
+          onChange={(nextRoleCodes: string[]) => {
+            setAssignRoleCodes(normalizeRoleCodes(nextRoleCodes));
+          }}
           options={roleOptions}
           loading={rolesLoading}
           placeholder="请选择角色"

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -101,21 +101,21 @@ export const router = createBrowserRouter([
         path: 'system/user/register',
         element: withPermission(
           <UserRegister />,
-          [PERMISSION_CODE.USER_MANAGE],
+          [PERMISSION_CODE.USER_MANAGE, PERMISSION_CODE.USER_READONLY],
         ),
       },
       {
         path: 'system/user/permission',
         element: withPermission(
           <UserPermission />,
-          [PERMISSION_CODE.USER_PERMISSION],
+          [PERMISSION_CODE.PERMISSION_MANAGE, PERMISSION_CODE.PERMISSION_READONLY],
         ),
       },
       {
         path: 'system/user/invite-code',
         element: withPermission(
           <InviteCode />,
-          [PERMISSION_CODE.INVITE_CODE_MANAGE],
+          [PERMISSION_CODE.INVITE_CODE_MANAGE, PERMISSION_CODE.INVITE_CODE_READONLY],
         ),
       },
       // 系统设置-系统-菜单管理
@@ -123,7 +123,7 @@ export const router = createBrowserRouter([
         path: 'system/menu',
         element: withPermission(
           <MenuManagement />,
-          [PERMISSION_CODE.MENU_MANAGE],
+          [PERMISSION_CODE.MENU_MANAGE, PERMISSION_CODE.MENU_READONLY],
         ),
       },
       {
@@ -138,7 +138,7 @@ export const router = createBrowserRouter([
         path: 'digital-employee/bots',
         element: withPermission(
           <BotManagement />,
-          [PERMISSION_CODE.BOT_MANAGE],
+          [PERMISSION_CODE.BOT_MANAGE, PERMISSION_CODE.BOT_READONLY],
         ),
       },
       // 数字员工-Agent管理
@@ -146,7 +146,7 @@ export const router = createBrowserRouter([
         path: 'digital-employee/agents',
         element: withPermission(
           <AgentManagement />,
-          [PERMISSION_CODE.AGENT_MANAGE],
+          [PERMISSION_CODE.AGENT_MANAGE, PERMISSION_CODE.AGENT_READONLY],
         ),
       },
       // ★ 动态路由兜底：菜单管理页面新增的菜单项若未在静态路由中注册，

--- a/frontend/src/utils/role-validation.ts
+++ b/frontend/src/utils/role-validation.ts
@@ -1,0 +1,41 @@
+import { EXCLUSIVE_ROLE_CODES, IDENTITY_ROLE_CODES } from '@/constants/access-control';
+
+/**
+ * 按角色分配规则规范化选中的角色集合：
+ * - 身份角色（super_admin / manager / user）之间互斥，最多保留一个。
+ * - 独占角色（super_admin / manager）不能叠加任何其他角色。
+ * - user 可叠加自定义角色。
+ *
+ * 身份角色冲突时的优先级：super_admin > manager > user，
+ * 即同时选中多个身份角色时保留权限最高者，避免依赖数组顺序。
+ */
+export function normalizeRoleCodes(selected: string[]): string[] {
+  const codes = [...new Set(selected)];
+  const identity = codes.filter((code) => IDENTITY_ROLE_CODES.has(code));
+
+  // 身份角色互斥：按固定优先级保留一个
+  if (identity.length > 1) {
+    const keptIdentity = identityPriority(identity);
+    // 若保留下来的身份角色是独占角色（super_admin / manager），
+    // 同样不能叠加自定义角色，需一并丢弃。
+    if (EXCLUSIVE_ROLE_CODES.has(keptIdentity)) {
+      return [keptIdentity];
+    }
+    return codes.filter(
+      (code) => !IDENTITY_ROLE_CODES.has(code) || code === keptIdentity,
+    );
+  }
+  // 独占角色不能叠加其他角色：保留独占角色，丢弃其他
+  const exclusive = codes.filter((code) => EXCLUSIVE_ROLE_CODES.has(code));
+  if (exclusive.length > 0 && codes.length > 1) {
+    return exclusive.slice(0, 1);
+  }
+  return codes;
+}
+
+/** 身份角色优先级：super_admin > manager > user。 */
+function identityPriority(identity: string[]): string {
+  if (identity.includes('super_admin')) return 'super_admin';
+  if (identity.includes('manager')) return 'manager';
+  return 'user';
+}

--- a/md/用户角色权限.md
+++ b/md/用户角色权限.md
@@ -199,15 +199,36 @@ CREATE TABLE IF NOT EXISTS role_menus (
 
 | 权限码 (Permission Code) | 模块归属 | 权限说明 | 影响的 API 接口 / 菜单路由 |
 | :--- | :--- | :--- | :--- |
-| `admin:user:manage` | 身份中心 | 用户列表查询、账号启用/禁用、密码重置、基础信息修改 | `GET/POST/PUT /api/v1/users` |
-| `admin:user:permission` | 身份中心 | 角色创建与修改、角色权限点分配、用户角色授权 | `GET/POST/PUT /api/v1/roles`, `/api/v1/permissions` |
-| `admin:invite_code:manage` | 身份中心 | 注册邀请码的生成、查询、失效处理 | `GET/POST /api/v1/invite-codes` |
+| `admin:user:manage` | 身份中心 | 用户列表查询、账号启用/禁用、密码重置、基础信息修改 | `GET/POST/PUT/DELETE /api/v1/users` |
+| `admin:user:readonly` | 身份中心 | 用户列表只读查看，不可增删改 | `GET /api/v1/users` |
+| `admin:permission:manage` | 身份中心 | 角色创建与修改、角色权限点分配、用户角色授权 | `GET/POST/PUT/DELETE /api/v1/roles`, `/api/v1/permissions` |
+| `admin:permission:readonly` | 身份中心 | 角色与授权信息只读查看，不可修改 | `GET /api/v1/roles`, `GET /api/v1/permissions` |
+| `admin:invite_code:manage` | 身份中心 | 注册邀请码的生成、查询、失效处理 | `GET/POST/DELETE /api/v1/invite-codes` |
+| `admin:invite_code:readonly` | 身份中心 | 邀请码列表只读查看，不可增删改 | `GET /api/v1/invite-codes` |
 | `admin:menu:manage` | 身份中心 | 动态菜单项增删改查、菜单路由与权限码绑定 | `GET/POST/PUT/DELETE /api/v1/menus` |
+| `admin:menu:readonly` | 身份中心 | 菜单项只读查看，不可增删改 | `GET /api/v1/menus` |
 | `admin:bot:manage` | 数字员工 | IM 机器人接入配置、AppID/AppSecret 凭证更新、网关探活 | `GET/POST/PUT/DELETE /api/v1/bots` |
+| `admin:bot:readonly` | 数字员工 | 机器人列表只读查看，不可增删改 | `GET /api/v1/bots` |
+| `admin:agent:manage` | 数字员工 | Agent 定义与生命周期管理 | `GET/POST/PUT/DELETE /api/v1/agents` |
+| `admin:agent:readonly` | 数字员工 | Agent 列表只读查看，不可增删改 | `GET /api/v1/agents` |
 | `admin:data_platform:dashboard` | 数据平台 | 数据平台仪表盘与系统统计数据查看 | `GET /api/v1/data-items/stats` |
 | `admin:data_platform:data_items` | 数据平台 | 数据平台业务数据条目 CRUD 操作 | `GET/POST/PUT/DELETE /api/v1/data-items` |
 | `admin:data_platform:config` | 数据平台 | 数据平台全局环境变量与参数配置 | `GET/PUT /api/v1/system-config` |
 | `admin:observability:log:view` | 可观测性 | 分布式链路日志与系统运行 Log 查看 | `GET /api/v1/observability/logs` |
+
+> **读写分级约定**：每个管理模块拆分为 `manage`（管理：读 + 写）与 `readonly`（只读：仅查看）两级权限码。
+> 后端 GET（读）接口同时接受 `manage` 与 `readonly`（OR 语义）；POST/PUT/DELETE（写）接口仅接受 `manage`。
+> 前端在只读权限下隐藏所有新建/编辑/删除等写操作入口，仅保留查看与刷新能力。
+>
+> **菜单可见性约定**：管理菜单的 `menus.permission` 字段绑定 `readonly` 码（最低可见权限）。
+> `manage` 是 `readonly` 的超集——持有 `xxx:manage` 的用户同样能看到绑 `xxx:readonly` 的菜单
+> （由 `backend-data` 的 `expand_manage_to_readonly` 统一处理）。因此：
+> - 分配管理菜单给角色 → 角色自动获得对应的 `readonly` 权限码（只读）
+> - 授予 `manage` 权限码 → 通过「用户独立权限分配」单独授予（角色模板不自动授予 manage）
+>
+> **数据迁移影响**：菜单 `permission` 从 `xxx:manage` 改为 `xxx:readonly` 后，重新执行菜单分配
+> 会把既有角色的权限码从 `manage` 同步降级为 `readonly`。上线时需先为需要写权限的账号
+> 通过用户独立权限分配补授 `manage` 权限码，避免管理员失去写操作能力。
 
 ---
 


### PR DESCRIPTION
## 变更概述

本次提交将权限体系重构为读写分级，并新增身份角色互斥校验。

### 核心变更

- **权限码读写分级**：每个管理模块权限码拆分为 \manage\（读+写）与 \eadonly\（只读）两级
- **扩展逻辑**：新增 \xpand_manage_to_readonly\，将 \manage\ 权限码扩展出对应的 \eadonly\ 变体
- **身份角色互斥校验**：新增 \alidate_role_codes\，super_admin / manager / user 三者互斥，manager / super_admin 为独占角色
- **前端适配**：只读权限下隐藏写操作入口，菜单 \permission\ 字段绑定 \eadonly\ 码
- **文档同步**：更新 \md/用户角色权限.md\ 权限码表与读写分级约定

### 影响范围

- backend-auth / backend-data（权限路由与服务）
- backend-share/auth-utils、data-client
- frontend（权限码常量、用户权限、菜单、Bot/Agent 管理）
- 文档

### 说明

- 新增测试文件未纳入本次提交，将在后续单独提交。
- 菜单 \permission\ 从 \xxx:manage\ 改为 \xxx:readonly\ 后，需为需要写权限的账号补授 \manage\ 权限码（详见文档数据迁移影响）。