### PR TITLE
fix: 放开 vite host 限制以允许任意域名/IP 访问

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -31,14 +31,18 @@ export default defineConfig(({ mode }) => {
       alias: [{ find: '@', replacement: path.resolve(__dirname, 'src') }],
     },
     server: {
+      host: true, // 监听所有本地 IP（0.0.0.0），允许通过任意域名/IP 访问
       port: 5173,
       strictPort: true,
       proxy,
+      allowedHosts: true, // 允许任意 Host 头（含 employee.rjgjx.top），不再拦截
     },
     preview: {
+      host: true, // 同上，preview 模式也允许任意域名/IP 访问
       port: 5173,
       strictPort: true,
       proxy,
+      allowedHosts: true, // 同上，preview 模式放行所有 Host
     },
     build: {
       rollupOptions: {


### PR DESCRIPTION
## 背景
部署到 `employee.rjgjx.top` 等自定义域名时,Vite 的 host 校验拦截请求:
> Blocked request. This host ("employee.rjgjx.top") is not allowed.

## 改动
- `frontend/vite.config.ts` 的 `server` 与 `preview` 增加 `host: true`(监听 0.0.0.0,允许任意 IP/域名访问)。
- 同时增加 `allowedHosts: true`,放行所有 Host 头,解除 Vite 6 的 DNS 重绑定防护对自定义域名的拦截。

## 验证
- 重启 dev / preview 后,通过 `employee.rjgjx.top` 等域名可正常访问,不再报 host not allowed。
- 端口仍为 5173,strictPort 与 proxy 配置保持不变。

🤖 Generated with WorkBuddy